### PR TITLE
Organisation's link in course details

### DIFF
--- a/django_project/certification/templates/course/detail.html
+++ b/django_project/certification/templates/course/detail.html
@@ -93,7 +93,15 @@
                         </div>
                         <div class="columns">
                             <div class="column is-4 has-text-weight-medium">Organisation:</div>
-                            <div class="column">{{ course.certifying_organisation.name }}</div>
+                            <div class="column">
+                                {% if course.certifying_organisation.url %}
+                                    <a href="{{ course.certifying_organisation.url }}" target="_blank" rel="noopener noreferrer">
+                                        {{ course.certifying_organisation.name }}
+                                    </a>
+                                {% else %}
+                                    {{ course.certifying_organisation.name }}
+                                {% endif %}
+                            </div>
                         </div>
                         <div class="columns">
                             <div class="column is-4 has-text-weight-medium">Start date:</div>


### PR DESCRIPTION
Fix for #21 

I think we can transform the organisation's name into a clickable link that redirects to the organisation's website. I will save us from adding a new field to only show the URL as it's already the case in the organization's dashboard.

Cc @geomenke

![image](https://github.com/user-attachments/assets/7dd07fa9-8652-4a89-a702-8aadcc3edfdf)
