### PR TITLE
Make template_certificate field optional in CourseForm

### DIFF
--- a/django_project/certification/forms.py
+++ b/django_project/certification/forms.py
@@ -408,7 +408,7 @@ class CourseForm(forms.ModelForm):
             attrs={'class': 'form-control', 'maxlength': '120'}
         ),
     )
-    template_certificate = forms.ImageField(widget=FileUploadInput)
+    template_certificate = forms.ImageField(widget=FileUploadInput, required=False)
 
     class Meta:
         model = Course


### PR DESCRIPTION
Fix for #34 

![image](https://github.com/user-attachments/assets/196444af-790c-46e8-9f3d-b47e2e9bd3ce)
