### PR TITLE
Automated invoice generation & emailing on credit top-up

### DIFF
--- a/django_project/base/migrations/0010_project_invoice_issuer_fields.py
+++ b/django_project/base/migrations/0010_project_invoice_issuer_fields.py
@@ -1,0 +1,121 @@
+# Generated for issue #101 (automated invoice sending)
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("base", "0009_remove_project_changelog_managers_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="project",
+            name="invoice_issuer_name",
+            field=models.CharField(
+                blank=True,
+                default="QGIS.ORG",
+                help_text=(
+                    "Issuer (seller) name displayed on credit purchase "
+                    "invoices."
+                ),
+                max_length=200,
+            ),
+        ),
+        migrations.AddField(
+            model_name="project",
+            name="invoice_issuer_address",
+            field=models.TextField(
+                blank=True,
+                default="Via Geinas 2\nCH-7031 Laax",
+                help_text=(
+                    "Issuer postal address displayed on credit purchase "
+                    "invoices."
+                ),
+            ),
+        ),
+        migrations.AddField(
+            model_name="project",
+            name="invoice_issuer_vat",
+            field=models.CharField(
+                blank=True,
+                default="UID-Nr: CHE-489.853.176",
+                help_text=(
+                    "Issuer VAT or company registration number "
+                    "(rendered as e.g. 'UID-Nr: CHE-…')."
+                ),
+                max_length=100,
+            ),
+        ),
+        migrations.AddField(
+            model_name="project",
+            name="invoice_issuer_email",
+            field=models.EmailField(
+                blank=True,
+                default="finance@qgis.org",
+                help_text="Issuer contact email displayed on invoices.",
+                max_length=254,
+            ),
+        ),
+        migrations.AddField(
+            model_name="project",
+            name="invoice_issuer_phone",
+            field=models.CharField(
+                blank=True,
+                default="Mobile: +41 79 938 11 71",
+                help_text="Issuer contact phone displayed on invoices.",
+                max_length=50,
+            ),
+        ),
+        migrations.AddField(
+            model_name="project",
+            name="invoice_issuer_bank_details",
+            field=models.TextField(
+                blank=True,
+                default=(
+                    "Bank name and address:\n\n"
+                    "PostFinance AG\n"
+                    "Mingerstrasse 20\n"
+                    "3030 Berne\n"
+                    "Switzerland\n\n"
+                    "Account Name: QGIS.ORG Association\n"
+                    "Account Holder Address: Via Geinas 2, CH-7031 Laax, "
+                    "Switzerland\n"
+                    "IBAN (account nr): CH09 0900 0000 9146 3839 8\n"
+                    "BIC/SWIFT: POFICHBEXXX"
+                ),
+                help_text=(
+                    "Issuer bank details / IBAN / SWIFT shown in invoice "
+                    "footer."
+                ),
+            ),
+        ),
+        migrations.AddField(
+            model_name="project",
+            name="invoice_number_prefix",
+            field=models.CharField(
+                blank=True,
+                default="QGIS",
+                help_text=(
+                    "Prefix used in invoice numbers, e.g. 'QGIS' -> "
+                    "'QGIS-2026-0001'."
+                ),
+                max_length=20,
+            ),
+        ),
+        migrations.AddField(
+            model_name="project",
+            name="invoice_tax_rate",
+            field=models.DecimalField(
+                blank=True,
+                decimal_places=2,
+                help_text=(
+                    "Tax / VAT percentage applied to invoices. Leave blank "
+                    "for no tax line."
+                ),
+                max_digits=5,
+                null=True,
+            ),
+        ),
+    ]

--- a/django_project/base/migrations/0010_project_invoice_issuer_fields.py
+++ b/django_project/base/migrations/0010_project_invoice_issuer_fields.py
@@ -96,10 +96,10 @@ class Migration(migrations.Migration):
             name="invoice_number_prefix",
             field=models.CharField(
                 blank=True,
-                default="QGIS",
+                default="QGIS-Cert",
                 help_text=(
-                    "Prefix used in invoice numbers, e.g. 'QGIS' -> "
-                    "'QGIS-2026-0001'."
+                    "Prefix used in invoice numbers, e.g. 'QGIS-Cert' -> "
+                    "'QGIS-Cert-26-0001'."
                 ),
                 max_length=20,
             ),

--- a/django_project/base/models/project.py
+++ b/django_project/base/models/project.py
@@ -214,10 +214,10 @@ class Project(models.Model):
     )
 
     invoice_number_prefix = models.CharField(
-        help_text=_("Prefix used in invoice numbers, e.g. 'QGIS' -> 'QGIS-2026-0001'."),
+        help_text=_("Prefix used in invoice numbers, e.g. 'QGIS-Cert' -> 'QGIS-Cert-26-0001'."),
         max_length=20,
         blank=True,
-        default="QGIS",
+        default="QGIS-Cert",
     )
 
     invoice_tax_rate = models.DecimalField(

--- a/django_project/base/models/project.py
+++ b/django_project/base/models/project.py
@@ -162,6 +162,73 @@ class Project(models.Model):
         blank=True,
     )
 
+    invoice_issuer_name = models.CharField(
+        help_text=_("Issuer (seller) name displayed on credit purchase invoices."),
+        max_length=200,
+        blank=True,
+        default="QGIS.ORG",
+    )
+
+    invoice_issuer_address = models.TextField(
+        help_text=_("Issuer postal address displayed on credit purchase invoices."),
+        blank=True,
+        default="Via Geinas 2\nCH-7031 Laax",
+    )
+
+    invoice_issuer_vat = models.CharField(
+        help_text=_(
+            "Issuer VAT or company registration number "
+            "(rendered as e.g. 'UID-Nr: CHE-…')."),
+        max_length=100,
+        blank=True,
+        default="UID-Nr: CHE-489.853.176",
+    )
+
+    invoice_issuer_email = models.EmailField(
+        help_text=_("Issuer contact email displayed on invoices."),
+        blank=True,
+        default="finance@qgis.org",
+    )
+
+    invoice_issuer_phone = models.CharField(
+        help_text=_("Issuer contact phone displayed on invoices."),
+        max_length=50,
+        blank=True,
+        default="Mobile: +41 79 938 11 71",
+    )
+
+    invoice_issuer_bank_details = models.TextField(
+        help_text=_("Issuer bank details / IBAN / SWIFT shown in invoice footer."),
+        blank=True,
+        default=(
+            "Bank name and address:\n\n"
+            "PostFinance AG\n"
+            "Mingerstrasse 20\n"
+            "3030 Berne\n"
+            "Switzerland\n\n"
+            "Account Name: QGIS.ORG Association\n"
+            "Account Holder Address: Via Geinas 2, CH-7031 Laax, Switzerland\n"
+            "IBAN (account nr): CH09 0900 0000 9146 3839 8\n"
+            "BIC/SWIFT: POFICHBEXXX"
+        ),
+    )
+
+    invoice_number_prefix = models.CharField(
+        help_text=_("Prefix used in invoice numbers, e.g. 'QGIS' -> 'QGIS-2026-0001'."),
+        max_length=20,
+        blank=True,
+        default="QGIS",
+    )
+
+    invoice_tax_rate = models.DecimalField(
+        help_text=_(
+            "Tax / VAT percentage applied to invoices. Leave blank for no tax line."),
+        max_digits=5,
+        decimal_places=2,
+        null=True,
+        blank=True,
+    )
+
     private = models.BooleanField(
         help_text=_("Only visible to logged-in users?"), default=False
     )

--- a/django_project/certification/admin.py
+++ b/django_project/certification/admin.py
@@ -19,6 +19,7 @@ from certification.models.checklist import Checklist
 from certification.models.organisation_checklist import OrganisationChecklist
 from certification.models.external_reviewer import ExternalReviewer
 from certification.models.credits_order import CreditsOrder
+from certification.models.invoice import Invoice
 
 
 class CertificateAdmin(admin.ModelAdmin):
@@ -155,8 +156,9 @@ class CertifyingOrganisationAdmin(SimpleHistoryAdmin):
     """Certifying organisation admin model."""
 
     filter_horizontal = ('organisation_owners',)
-    search_fields = ['name']
-    list_display = ('name', 'project', 'country', 'approved', 'rejected')
+    search_fields = ['name', 'vat_number']
+    list_display = (
+        'name', 'project', 'country', 'vat_number', 'approved', 'rejected')
     list_filter = ('country', 'approved', 'rejected', 'status')
     inlines = (CertifyingOrganisationCertificateAdminInline, )
     history_list_display = ['status', 'remarks']
@@ -196,6 +198,20 @@ class ExternalReviewerAdmin(admin.ModelAdmin):
     )
 
 
+class InvoiceAdmin(admin.ModelAdmin):
+    list_display = (
+        'invoice_number', 'issue_date', 'billing_name', 'total', 'currency',
+    )
+    search_fields = (
+        'invoice_number', 'billing_name', 'billing_vat_number',
+        'payment_reference',
+    )
+    list_filter = ('issue_date', 'currency')
+    readonly_fields = tuple(
+        f.name for f in Invoice._meta.fields if f.name != 'id'
+    )
+
+
 class CreditsOrderAdmin(admin.ModelAdmin):
     list_display = (
         'organisation',
@@ -224,3 +240,4 @@ admin.site.register(Checklist, ChecklistAdmin)
 admin.site.register(OrganisationChecklist, OrganisationChecklistAdmin)
 admin.site.register(ExternalReviewer, ExternalReviewerAdmin)
 admin.site.register(CreditsOrder, CreditsOrderAdmin)
+admin.site.register(Invoice, InvoiceAdmin)

--- a/django_project/certification/forms.py
+++ b/django_project/certification/forms.py
@@ -57,6 +57,16 @@ class CertifyingOrganisationForm(forms.ModelForm):
 
     logo = forms.ImageField(widget=FileUploadInput, required=False)
 
+    vat_number = forms.CharField(
+        required=False,
+        max_length=50,
+        widget=forms.TextInput(attrs={'style': 'text-transform: uppercase;'}),
+    )
+
+    def clean_vat_number(self):
+        value = self.cleaned_data.get('vat_number') or ''
+        return value.strip().upper()
+
     # noinspection PyClassicStyleClass.
     class Meta:
         model = CertifyingOrganisation
@@ -67,6 +77,7 @@ class CertifyingOrganisationForm(forms.ModelForm):
             'address',
             'country',
             'organisation_phone',
+            'vat_number',
             'logo',
             'owner_message',
             'organisation_owners',
@@ -91,6 +102,7 @@ class CertifyingOrganisationForm(forms.ModelForm):
                 Field('address', css_class='form-control'),
                 Field('country', css_class='form-control'),
                 Field('organisation_phone', css_class='form-control'),
+                Field('vat_number', css_class='form-control'),
                 Field('logo', css_class='form-control'),
                 Field('owner_message', css_class='form-control'),
                 Field('organisation_owners', css_class='is-fullwidth'),

--- a/django_project/certification/forms.py
+++ b/django_project/certification/forms.py
@@ -60,12 +60,8 @@ class CertifyingOrganisationForm(forms.ModelForm):
     vat_number = forms.CharField(
         required=False,
         max_length=50,
-        widget=forms.TextInput(attrs={'style': 'text-transform: uppercase;'}),
+        label='VAT or company registration number',
     )
-
-    def clean_vat_number(self):
-        value = self.cleaned_data.get('vat_number') or ''
-        return value.strip().upper()
 
     # noinspection PyClassicStyleClass.
     class Meta:

--- a/django_project/certification/invoice_utils.py
+++ b/django_project/certification/invoice_utils.py
@@ -1,0 +1,190 @@
+# coding=utf-8
+"""Invoice creation, PDF rendering and email delivery."""
+
+import ast
+import logging
+import os
+from decimal import Decimal, ROUND_HALF_UP
+
+from django.conf import settings
+from django.core.files.base import ContentFile
+from django.core.mail import EmailMessage, get_connection
+from django.db import transaction
+from django.template.loader import render_to_string
+
+logger = logging.getLogger(__name__)
+
+
+def _quantize(amount: Decimal) -> Decimal:
+    return amount.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+
+
+def render_invoice_pdf(invoice) -> bytes:
+    """Render the invoice as a PDF using WeasyPrint."""
+    from weasyprint import HTML  # imported lazily — weasyprint loads native libs
+
+    project = invoice.credits_order.organisation.project
+    logo_url = ''
+    if project.image_file:
+        try:
+            logo_url = project.image_file.path
+        except (ValueError, NotImplementedError):
+            logo_url = project.image_file.url
+
+    html = render_to_string(
+        'invoice/invoice.html',
+        {'invoice': invoice, 'logo_url': logo_url},
+    )
+    return HTML(string=html, base_url=settings.MEDIA_ROOT).write_pdf()
+
+
+def send_invoice_email(invoice) -> None:
+    """Email the invoice (PDF attached) to organisation owners."""
+    organisation = invoice.credits_order.organisation
+    recipients = {
+        owner.email for owner in organisation.organisation_owners.all() if owner.email
+    }
+    if organisation.organisation_email:
+        recipients.add(organisation.organisation_email)
+    if not recipients:
+        logger.warning(
+            "No recipients found for invoice %s — email skipped.",
+            invoice.invoice_number,
+        )
+        return
+
+    connection = None
+    if settings.DEBUG:
+        # Reroute every dev invoice to the dev team and force a real SMTP
+        # connection — the dev EMAIL_BACKEND is the console backend, which
+        # would otherwise dump the full MIME (incl. the base64 PDF) into the
+        # logs and never actually deliver the email. SMTP credentials are
+        # pulled from env vars (the dev settings hardcode EMAIL_HOST to
+        # localhost, which would refuse the connection).
+        logger.info(
+            "DEBUG mode: redirecting invoice %s email from %s to the dev team.",
+            invoice.invoice_number,
+            sorted(recipients),
+        )
+        recipients = os.environ.get('ADMIN_EMAIL', '').split(',')
+        try:
+            use_tls = ast.literal_eval(os.environ.get('EMAIL_USE_TLS', 'True'))
+        except (ValueError, SyntaxError):
+            use_tls = True
+        connection = get_connection(
+            backend='django.core.mail.backends.smtp.EmailBackend',
+            host=os.environ.get('EMAIL_HOST', 'smtp.resend.com'),
+            port=int(os.environ.get('EMAIL_PORT', '587') or 587),
+            username=os.environ.get('EMAIL_HOST_USER') or None,
+            password=os.environ.get('EMAIL_HOST_PASSWORD') or None,
+            use_tls=bool(use_tls),
+        )
+
+    ctx = {'invoice': invoice, 'organisation': organisation}
+    subject = f"QGIS Certification: Invoice {invoice.invoice_number}"
+    text_body = render_to_string('email/invoice_email.txt', ctx)
+
+    msg = EmailMessage(
+        subject=subject,
+        body=text_body,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        to=sorted(recipients),
+        connection=connection,
+    )
+    if invoice.pdf:
+        invoice.pdf.open('rb')
+        try:
+            pdf_bytes = invoice.pdf.read()
+        finally:
+            invoice.pdf.close()
+        msg.attach(f"{invoice.invoice_number}.pdf", pdf_bytes, 'application/pdf')
+    msg.send()
+
+
+def create_and_send_invoice(credits_order, payrexx_transaction=None):
+    """Create an Invoice record for a paid CreditsOrder and email it.
+
+    Idempotent: re-invocation for the same CreditsOrder is a no-op so the
+    Payrexx webhook can safely retry. PDF rendering / email failures are
+    logged but never raise — the credits have already been issued and we do
+    not want to fail the webhook.
+    """
+    from certification.models.invoice import Invoice
+
+    organisation = credits_order.organisation
+    project = organisation.project
+
+    with transaction.atomic():
+        existing = (
+            Invoice.objects
+            .select_for_update()
+            .filter(credits_order=credits_order)
+            .first()
+        )
+        if existing:
+            logger.info(
+                "Invoice %s already exists for credits order %s — skipping.",
+                existing.invoice_number,
+                credits_order.pk,
+            )
+            return existing
+
+        quantity = credits_order.credits_requested
+        unit_price = Decimal(project.credit_cost or 0)
+        subtotal = _quantize(unit_price * Decimal(quantity))
+        tax_rate = project.invoice_tax_rate
+        if tax_rate is not None:
+            tax_amount = _quantize(subtotal * Decimal(tax_rate) / Decimal('100'))
+        else:
+            tax_amount = Decimal('0.00')
+        total = _quantize(subtotal + tax_amount)
+
+        payment_reference = ''
+        if payrexx_transaction:
+            payment_reference = str(payrexx_transaction.get('id', '')) or ''
+
+        invoice = Invoice.objects.create(
+            credits_order=credits_order,
+            invoice_number=Invoice.generate_number(project),
+            billing_name=organisation.name,
+            billing_address=organisation.address or '',
+            billing_email=organisation.organisation_email or '',
+            billing_vat_number=organisation.vat_number or '',
+            billing_country=organisation.country or '',
+            issuer_name=project.invoice_issuer_name or '',
+            issuer_address=project.invoice_issuer_address or '',
+            issuer_vat=project.invoice_issuer_vat or '',
+            issuer_email=project.invoice_issuer_email or '',
+            issuer_phone=project.invoice_issuer_phone or '',
+            issuer_url=project.project_url or '',
+            issuer_bank_details=project.invoice_issuer_bank_details or '',
+            quantity=quantity,
+            unit_price=unit_price,
+            currency=project.credit_cost_currency or '',
+            subtotal=subtotal,
+            tax_rate=tax_rate,
+            tax_amount=tax_amount,
+            total=total,
+            payment_reference=payment_reference,
+        )
+
+    # PDF + email outside the DB transaction so a render/send failure does
+    # not roll back the persisted Invoice (we want the record kept either way).
+    try:
+        pdf_bytes = render_invoice_pdf(invoice)
+        invoice.pdf.save(
+            f"{invoice.invoice_number}.pdf",
+            ContentFile(pdf_bytes),
+            save=True,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to render PDF for invoice %s", invoice.invoice_number)
+
+    try:
+        send_invoice_email(invoice)
+    except Exception:
+        logger.exception(
+            "Failed to send invoice email for %s", invoice.invoice_number)
+
+    return invoice

--- a/django_project/certification/migrations/0030_certifyingorganisation_vat_number_invoice.py
+++ b/django_project/certification/migrations/0030_certifyingorganisation_vat_number_invoice.py
@@ -1,0 +1,135 @@
+# Generated for issue #101 (automated invoice sending)
+
+from decimal import Decimal
+
+import django.db.models.deletion
+import django_countries.fields
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("certification", "0029_creditsorder"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="certifyingorganisation",
+            name="vat_number",
+            field=models.CharField(
+                blank=True,
+                help_text=(
+                    "VAT or company registration number "
+                    "(optional, shown on invoices)."
+                ),
+                max_length=50,
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="historicalcertifyingorganisation",
+            name="vat_number",
+            field=models.CharField(
+                blank=True,
+                help_text=(
+                    "VAT or company registration number "
+                    "(optional, shown on invoices)."
+                ),
+                max_length=50,
+                null=True,
+            ),
+        ),
+        migrations.CreateModel(
+            name="Invoice",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("invoice_number", models.CharField(max_length=50, unique=True)),
+                ("issue_date", models.DateField(auto_now_add=True)),
+                ("billing_name", models.CharField(max_length=200)),
+                ("billing_address", models.TextField()),
+                (
+                    "billing_email",
+                    models.CharField(blank=True, default="", max_length=200),
+                ),
+                (
+                    "billing_vat_number",
+                    models.CharField(blank=True, default="", max_length=50),
+                ),
+                (
+                    "billing_country",
+                    django_countries.fields.CountryField(blank=True, max_length=2),
+                ),
+                (
+                    "issuer_name",
+                    models.CharField(blank=True, default="", max_length=200),
+                ),
+                ("issuer_address", models.TextField(blank=True, default="")),
+                (
+                    "issuer_vat",
+                    models.CharField(blank=True, default="", max_length=100),
+                ),
+                (
+                    "issuer_email",
+                    models.CharField(blank=True, default="", max_length=200),
+                ),
+                (
+                    "issuer_phone",
+                    models.CharField(blank=True, default="", max_length=50),
+                ),
+                (
+                    "issuer_url",
+                    models.URLField(blank=True, default="", max_length=200),
+                ),
+                ("issuer_bank_details", models.TextField(blank=True, default="")),
+                (
+                    "quantity",
+                    models.IntegerField(help_text="Number of credits purchased."),
+                ),
+                ("unit_price", models.DecimalField(decimal_places=2, max_digits=10)),
+                ("currency", models.CharField(max_length=10)),
+                ("subtotal", models.DecimalField(decimal_places=2, max_digits=12)),
+                (
+                    "tax_rate",
+                    models.DecimalField(
+                        blank=True, decimal_places=2, max_digits=5, null=True
+                    ),
+                ),
+                (
+                    "tax_amount",
+                    models.DecimalField(
+                        decimal_places=2, default=Decimal("0.00"), max_digits=12
+                    ),
+                ),
+                ("total", models.DecimalField(decimal_places=2, max_digits=12)),
+                (
+                    "payment_reference",
+                    models.CharField(blank=True, default="", max_length=100),
+                ),
+                (
+                    "pdf",
+                    models.FileField(blank=True, upload_to="invoices/%Y/%m/"),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "credits_order",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="invoice",
+                        to="certification.creditsorder",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-issue_date", "-id"],
+            },
+        ),
+    ]

--- a/django_project/certification/models/__init__.py
+++ b/django_project/certification/models/__init__.py
@@ -17,3 +17,4 @@ from certification.models.checklist import *
 from certification.models.organisation_checklist import *
 from certification.models.external_reviewer import *
 from certification.models.credits_order import *
+from certification.models.invoice import *

--- a/django_project/certification/models/certifying_organisation.py
+++ b/django_project/certification/models/certifying_organisation.py
@@ -145,6 +145,15 @@ class CertifyingOrganisation(models.Model):
         blank=False
     )
 
+    vat_number = models.CharField(
+        help_text=_(
+            'VAT or company registration number '
+            '(optional, shown on invoices).'),
+        max_length=50,
+        null=True,
+        blank=True,
+    )
+
     organisation_credits = models.IntegerField(
         help_text=_('Credits available'),
         default=0,

--- a/django_project/certification/models/invoice.py
+++ b/django_project/certification/models/invoice.py
@@ -86,12 +86,12 @@ class Invoice(models.Model):
     def generate_number(cls, project):
         """Return the next sequential invoice number for the given project.
 
-        Format: ``{PREFIX}-{YYYY}-{NNNN}``. Uses ``select_for_update`` so two
+        Format: ``{PREFIX}-{YY}-{NNNN}``. Uses ``select_for_update`` so two
         concurrent callers cannot allocate the same number.
         """
-        prefix = (project.invoice_number_prefix or 'INV').strip()
-        year = timezone.now().year
-        search_prefix = f'{prefix}-{year}-'
+        prefix = (project.invoice_number_prefix or 'QGIS-Cert').strip()
+        year = timezone.now().year % 100
+        search_prefix = f'{prefix}-{year:02d}-'
 
         with transaction.atomic():
             last = (

--- a/django_project/certification/models/invoice.py
+++ b/django_project/certification/models/invoice.py
@@ -1,0 +1,111 @@
+# coding=utf-8
+"""Invoice model for credit purchases."""
+
+from datetime import timedelta
+from decimal import Decimal
+
+from django.db import models, transaction
+from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
+from django_countries.fields import CountryField
+
+from certification.models.credits_order import CreditsOrder
+
+
+CURRENCY_SYMBOLS = {
+    'EUR': '€',
+    'USD': '$',
+    'GBP': '£',
+    'CHF': 'CHF',
+}
+
+
+class Invoice(models.Model):
+    """Invoice issued when an organisation buys credits.
+
+    Holds a frozen snapshot of billing and issuer data so historical
+    invoices stay correct even when the underlying records change later.
+    """
+
+    credits_order = models.OneToOneField(
+        CreditsOrder,
+        on_delete=models.PROTECT,
+        related_name='invoice',
+    )
+    invoice_number = models.CharField(max_length=50, unique=True)
+    issue_date = models.DateField(auto_now_add=True)
+
+    # Billing snapshot
+    billing_name = models.CharField(max_length=200)
+    billing_address = models.TextField()
+    billing_email = models.CharField(max_length=200, blank=True, default="")
+    billing_vat_number = models.CharField(max_length=50, blank=True, default="")
+    billing_country = CountryField(blank=True)
+
+    # Issuer snapshot
+    issuer_name = models.CharField(max_length=200, blank=True, default="")
+    issuer_address = models.TextField(blank=True, default="")
+    issuer_vat = models.CharField(max_length=100, blank=True, default="")
+    issuer_email = models.CharField(max_length=200, blank=True, default="")
+    issuer_phone = models.CharField(max_length=50, blank=True, default="")
+    issuer_url = models.URLField(max_length=200, blank=True, default="")
+    issuer_bank_details = models.TextField(blank=True, default="")
+
+    # Amounts
+    quantity = models.IntegerField(help_text=_("Number of credits purchased."))
+    unit_price = models.DecimalField(max_digits=10, decimal_places=2)
+    currency = models.CharField(max_length=10)
+    subtotal = models.DecimalField(max_digits=12, decimal_places=2)
+    tax_rate = models.DecimalField(
+        max_digits=5, decimal_places=2, null=True, blank=True)
+    tax_amount = models.DecimalField(
+        max_digits=12, decimal_places=2, default=Decimal('0.00'))
+    total = models.DecimalField(max_digits=12, decimal_places=2)
+
+    payment_reference = models.CharField(max_length=100, blank=True, default="")
+    pdf = models.FileField(upload_to='invoices/%Y/%m/', blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        app_label = 'certification'
+        ordering = ['-issue_date', '-id']
+
+    def __str__(self):
+        return self.invoice_number
+
+    @property
+    def due_date(self):
+        """Default payment due date — 30 days after issue."""
+        return self.issue_date + timedelta(days=30)
+
+    @property
+    def currency_symbol(self):
+        return CURRENCY_SYMBOLS.get(self.currency.upper(), self.currency)
+
+    @classmethod
+    def generate_number(cls, project):
+        """Return the next sequential invoice number for the given project.
+
+        Format: ``{PREFIX}-{YYYY}-{NNNN}``. Uses ``select_for_update`` so two
+        concurrent callers cannot allocate the same number.
+        """
+        prefix = (project.invoice_number_prefix or 'INV').strip()
+        year = timezone.now().year
+        search_prefix = f'{prefix}-{year}-'
+
+        with transaction.atomic():
+            last = (
+                cls.objects
+                .select_for_update()
+                .filter(invoice_number__startswith=search_prefix)
+                .order_by('-invoice_number')
+                .first()
+            )
+            if last:
+                try:
+                    last_seq = int(last.invoice_number.rsplit('-', 1)[-1])
+                except ValueError:
+                    last_seq = 0
+            else:
+                last_seq = 0
+            return f'{search_prefix}{last_seq + 1:04d}'

--- a/django_project/certification/templates/email/invoice_email.txt
+++ b/django_project/certification/templates/email/invoice_email.txt
@@ -1,0 +1,13 @@
+Hello,
+
+Thank you for your credit purchase for {{ organisation.name }}.
+
+Invoice number: {{ invoice.invoice_number }}
+Issue date:     {{ invoice.issue_date|date:"d M Y" }}
+Credits added:  {{ invoice.quantity }}
+Total paid:     {{ invoice.total }} {{ invoice.currency }}
+
+A PDF copy of your invoice is attached to this email for your records.
+
+Kind regards,
+QGIS Certification Team

--- a/django_project/certification/templates/invoice/invoice.html
+++ b/django_project/certification/templates/invoice/invoice.html
@@ -1,0 +1,233 @@
+{% load static %}<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Invoice {{ invoice.invoice_number }}</title>
+<style>
+  @page {
+    size: A4;
+    margin: 18mm 18mm 22mm 18mm;
+    @bottom-center {
+      content: counter(page) "/" counter(pages);
+      font-size: 9pt;
+      color: #666;
+    }
+  }
+  body {
+    font-family: "Helvetica", "Arial", sans-serif;
+    font-size: 10.5pt;
+    color: #222;
+    line-height: 1.35;
+    margin: 0;
+  }
+  a { color: #0066cc; text-decoration: underline; }
+  table { border-collapse: collapse; width: 100%; }
+  pre.address {
+    font-family: inherit;
+    font-size: 10.5pt;
+    margin: 0;
+    white-space: pre-wrap;
+  }
+
+  /* Header: logo | issuer info | issuer contact */
+  table.header td { vertical-align: top; padding: 0; }
+  table.header td.logo { width: 110px; }
+  table.header td.logo img { width: 90px; height: auto; }
+  table.header td.issuer .name { font-weight: bold; }
+  table.header td.contact { text-align: right; }
+
+  /* Title row */
+  table.title { margin-top: 36px; }
+  table.title td { vertical-align: top; padding: 0; }
+  table.title h1 {
+    font-size: 20pt;
+    margin: 0;
+    letter-spacing: 0.5px;
+  }
+  table.title td.meta {
+    text-align: right;
+    padding-top: 6px;
+  }
+  table.title td.meta .meta-row { margin-bottom: 4px; }
+
+  /* Billing block */
+  .billto {
+    margin-top: 6px;
+  }
+  .billto .name { font-weight: bold; }
+
+  /* Items table */
+  table.items {
+    margin-top: 36px;
+    border-collapse: collapse;
+  }
+  table.items thead th {
+    border-bottom: 1px solid #000;
+    padding: 6px 4px;
+    text-align: left;
+    font-weight: bold;
+  }
+  table.items thead th.right { text-align: right; }
+  table.items tbody td {
+    border-bottom: 1px solid #ddd;
+    padding: 8px 4px;
+    vertical-align: top;
+  }
+  table.items tbody td.right { text-align: right; }
+  table.items tbody tr.total td {
+    border-bottom: 2px solid #000;
+    border-top: 1px solid #000;
+    font-weight: bold;
+  }
+
+  .paid-note {
+    margin-top: 18px;
+    text-align: center;
+    font-style: italic;
+  }
+
+  .due-date {
+    margin-top: 28px;
+    font-weight: bold;
+  }
+
+  .payment-details {
+    margin-top: 14px;
+  }
+  .payment-details .label { margin-bottom: 8px; }
+  .payment-details pre {
+    font-family: inherit;
+    font-size: 10.5pt;
+    margin: 0 0 10px 0;
+    white-space: pre-wrap;
+  }
+  .footer-notes { margin-top: 10px; }
+  .closing {
+    margin-top: 40px;
+    text-align: center;
+  }
+</style>
+</head>
+<body>
+
+<table class="header">
+  <tr>
+    <td class="logo">
+      {% if logo_url %}
+        <img src="{{ logo_url }}" alt="logo" />
+      {% endif %}
+    </td>
+    <td class="issuer">
+      {% if invoice.issuer_name %}
+        <div class="name">{{ invoice.issuer_name }}</div>
+      {% endif %}
+      {% if invoice.issuer_address %}
+        <pre class="address">{{ invoice.issuer_address }}</pre>
+      {% endif %}
+      {% if invoice.issuer_vat %}
+        <div>{{ invoice.issuer_vat }}</div>
+      {% endif %}
+    </td>
+    <td class="contact">
+      {% if invoice.issuer_url %}
+        <div><a href="{{ invoice.issuer_url }}">{{ invoice.issuer_url }}</a></div>
+      {% endif %}
+      {% if invoice.issuer_email %}
+        <div><a href="mailto:{{ invoice.issuer_email }}">{{ invoice.issuer_email }}</a></div>
+      {% endif %}
+      {% if invoice.issuer_phone %}
+        <div>{{ invoice.issuer_phone }}</div>
+      {% endif %}
+    </td>
+  </tr>
+</table>
+
+<table class="title">
+  <tr>
+    <td>
+      <h1>TAX INVOICE</h1>
+      <div class="billto">
+        <div class="name">{{ invoice.billing_name }}</div>
+        {% if invoice.billing_vat_number %}
+          <div>VAT ID: {{ invoice.billing_vat_number }}</div>
+        {% endif %}
+        <pre class="address">{{ invoice.billing_address }}</pre>
+        {% if invoice.billing_country %}
+          <div>{{ invoice.billing_country.name }}</div>
+        {% endif %}
+      </div>
+    </td>
+    <td class="meta">
+      <div class="meta-row"><strong>Invoice Date</strong>: {{ invoice.issue_date|date:"j M Y" }}</div>
+      <div class="meta-row"><strong>Invoice Number</strong>: {{ invoice.invoice_number }}</div>
+    </td>
+  </tr>
+</table>
+
+<table class="items">
+  <thead>
+    <tr>
+      <th style="width:55%">Description</th>
+      <th style="width:25%">VAT / GST</th>
+      <th class="right" style="width:20%">Amount {{ invoice.currency_symbol }}</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        {{ invoice.quantity }} QGIS certification credit{{ invoice.quantity|pluralize }}
+        à {{ invoice.unit_price }} {{ invoice.currency_symbol }} each
+      </td>
+      <td>
+        {% if invoice.tax_rate %}
+          {{ invoice.tax_rate }}%
+        {% else %}
+          VAT / GST free
+        {% endif %}
+      </td>
+      <td class="right">{{ invoice.subtotal }}</td>
+    </tr>
+    {% if invoice.tax_rate %}
+      <tr>
+        <td></td>
+        <td>Tax ({{ invoice.tax_rate }}%)</td>
+        <td class="right">{{ invoice.tax_amount }}</td>
+      </tr>
+    {% endif %}
+    <tr>
+      <td></td>
+      <td>Subtotal</td>
+      <td class="right">{{ invoice.subtotal }}</td>
+    </tr>
+    <tr class="total">
+      <td></td>
+      <td>TOTAL {{ invoice.currency_symbol }}</td>
+      <td class="right">{{ invoice.total }}</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="paid-note">
+  Invoice already paid through credit card on {{ invoice.issue_date|date:"M j, Y" }}.
+</div>
+
+<div class="due-date">Due Date: {{ invoice.due_date|date:"j M Y" }}</div>
+
+{% if invoice.issuer_bank_details %}
+  <div class="payment-details">
+    <div class="label">Payment Details for Bank Transfer:</div>
+    <pre>{{ invoice.issuer_bank_details }}</pre>
+  </div>
+{% endif %}
+
+<div class="footer-notes">
+  <div>Please use invoice number as payment description</div>
+  <div>Educational services are tax exempt in Switzerland</div>
+</div>
+
+<div class="closing">
+  Thank you for collaborating with {{ invoice.issuer_name|default:"us" }} on your QGIS training!
+</div>
+
+</body>
+</html>

--- a/django_project/certification/tests/model_factories.py
+++ b/django_project/certification/tests/model_factories.py
@@ -18,6 +18,8 @@ from certification.models import (
     CertifyingOrganisationCertificate,
     Checklist, OrganisationChecklist, ExternalReviewer,
 )
+from certification.models.credits_order import CreditsOrder
+from certification.models.invoice import Invoice
 from core.model_factories import UserF
 from base.tests.model_factories import ProjectF
 
@@ -206,3 +208,27 @@ class ExternalReviewerF(factory.django.DjangoModelFactory):
     email = factory.Sequence(
         lambda n: 'email%s@email.com' % n
     )
+
+
+class CreditsOrderF(factory.django.DjangoModelFactory):
+    class Meta:
+        model = CreditsOrder
+
+    organisation = factory.SubFactory(CertifyingOrganisationF)
+    credits_requested = 5
+
+
+class InvoiceF(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Invoice
+
+    credits_order = factory.SubFactory(CreditsOrderF)
+    invoice_number = factory.Sequence(lambda n: 'QGIS-2026-%04d' % (n + 1))
+    billing_name = 'Test organisation'
+    billing_address = 'Test address'
+    quantity = 5
+    unit_price = '10.00'
+    currency = 'EUR'
+    subtotal = '50.00'
+    tax_amount = '0.00'
+    total = '50.00'

--- a/django_project/certification/tests/test_invoice_number.py
+++ b/django_project/certification/tests/test_invoice_number.py
@@ -1,0 +1,80 @@
+# coding=utf-8
+"""Tests for Invoice.generate_number."""
+
+from datetime import date
+from unittest import mock
+
+from django.test import TestCase
+
+from base.tests.model_factories import ProjectF
+from certification.models.invoice import Invoice
+from certification.tests.model_factories import (
+    CertifyingOrganisationF,
+    CreditsOrderF,
+    InvoiceF,
+)
+
+
+class InvoiceNumberGenerationTest(TestCase):
+    def setUp(self):
+        # Pre-create the shared 'qgis' project once via the public `create`
+        # classmethod (which dedupes by name). All factory-generated
+        # sub-objects will then reuse this project instance.
+        self.project = ProjectF.create(invoice_number_prefix='QGIS')
+        self.project.invoice_number_prefix = 'QGIS'
+        self.project.save()
+        self.organisation = CertifyingOrganisationF.create(project=self.project)
+
+    def _make_order(self):
+        return CreditsOrderF.create(organisation=self.organisation)
+
+    def test_first_number_uses_prefix_and_year(self):
+        with mock.patch(
+            'certification.models.invoice.timezone.now',
+            return_value=mock.Mock(year=2026),
+        ):
+            number = Invoice.generate_number(self.project)
+        self.assertTrue(number.startswith('QGIS-2026-'))
+        self.assertTrue(number.endswith('-0001'))
+
+    def test_sequence_increments_per_year(self):
+        InvoiceF.create(
+            credits_order=self._make_order(),
+            invoice_number='QGIS-2026-0001',
+        )
+        InvoiceF.create(
+            credits_order=self._make_order(),
+            invoice_number='QGIS-2026-0002',
+        )
+        with mock.patch(
+            'certification.models.invoice.timezone.now',
+            return_value=mock.Mock(year=2026),
+        ):
+            number = Invoice.generate_number(self.project)
+        self.assertEqual(number, 'QGIS-2026-0003')
+
+    def test_falls_back_to_default_prefix_when_blank(self):
+        self.project.invoice_number_prefix = ''
+        self.project.save()
+        with mock.patch(
+            'certification.models.invoice.timezone.now',
+            return_value=mock.Mock(year=2026),
+        ):
+            number = Invoice.generate_number(self.project)
+        self.assertTrue(number.startswith('INV-2026-'))
+
+    def test_year_resets_sequence(self):
+        InvoiceF.create(
+            credits_order=self._make_order(),
+            invoice_number='QGIS-2025-0009',
+        )
+        with mock.patch(
+            'certification.models.invoice.timezone.now',
+            return_value=mock.Mock(year=2026),
+        ):
+            number = Invoice.generate_number(self.project)
+        self.assertEqual(number, 'QGIS-2026-0001')
+
+    def test_persisted_invoice_uses_today_date(self):
+        invoice = InvoiceF.create(credits_order=self._make_order())
+        self.assertEqual(invoice.issue_date, date.today())

--- a/django_project/certification/tests/test_invoice_number.py
+++ b/django_project/certification/tests/test_invoice_number.py
@@ -17,11 +17,8 @@ from certification.tests.model_factories import (
 
 class InvoiceNumberGenerationTest(TestCase):
     def setUp(self):
-        # Pre-create the shared 'qgis' project once via the public `create`
-        # classmethod (which dedupes by name). All factory-generated
-        # sub-objects will then reuse this project instance.
-        self.project = ProjectF.create(invoice_number_prefix='QGIS')
-        self.project.invoice_number_prefix = 'QGIS'
+        self.project = ProjectF.create(invoice_number_prefix='QGIS-Cert')
+        self.project.invoice_number_prefix = 'QGIS-Cert'
         self.project.save()
         self.organisation = CertifyingOrganisationF.create(project=self.project)
 
@@ -34,24 +31,24 @@ class InvoiceNumberGenerationTest(TestCase):
             return_value=mock.Mock(year=2026),
         ):
             number = Invoice.generate_number(self.project)
-        self.assertTrue(number.startswith('QGIS-2026-'))
+        self.assertTrue(number.startswith('QGIS-Cert-26-'))
         self.assertTrue(number.endswith('-0001'))
 
     def test_sequence_increments_per_year(self):
         InvoiceF.create(
             credits_order=self._make_order(),
-            invoice_number='QGIS-2026-0001',
+            invoice_number='QGIS-Cert-26-0001',
         )
         InvoiceF.create(
             credits_order=self._make_order(),
-            invoice_number='QGIS-2026-0002',
+            invoice_number='QGIS-Cert-26-0002',
         )
         with mock.patch(
             'certification.models.invoice.timezone.now',
             return_value=mock.Mock(year=2026),
         ):
             number = Invoice.generate_number(self.project)
-        self.assertEqual(number, 'QGIS-2026-0003')
+        self.assertEqual(number, 'QGIS-Cert-26-0003')
 
     def test_falls_back_to_default_prefix_when_blank(self):
         self.project.invoice_number_prefix = ''
@@ -61,19 +58,19 @@ class InvoiceNumberGenerationTest(TestCase):
             return_value=mock.Mock(year=2026),
         ):
             number = Invoice.generate_number(self.project)
-        self.assertTrue(number.startswith('INV-2026-'))
+        self.assertTrue(number.startswith('QGIS-Cert-26-'))
 
     def test_year_resets_sequence(self):
         InvoiceF.create(
             credits_order=self._make_order(),
-            invoice_number='QGIS-2025-0009',
+            invoice_number='QGIS-Cert-25-0009',
         )
         with mock.patch(
             'certification.models.invoice.timezone.now',
             return_value=mock.Mock(year=2026),
         ):
             number = Invoice.generate_number(self.project)
-        self.assertEqual(number, 'QGIS-2026-0001')
+        self.assertEqual(number, 'QGIS-Cert-26-0001')
 
     def test_persisted_invoice_uses_today_date(self):
         invoice = InvoiceF.create(credits_order=self._make_order())

--- a/django_project/certification/tests/test_invoice_pdf.py
+++ b/django_project/certification/tests/test_invoice_pdf.py
@@ -1,0 +1,86 @@
+# coding=utf-8
+"""Tests for invoice PDF rendering."""
+
+from decimal import Decimal
+
+from django.test import TestCase
+
+from base.tests.model_factories import ProjectF
+from certification.invoice_utils import (
+    create_and_send_invoice,
+    render_invoice_pdf,
+)
+from certification.models.invoice import Invoice
+from certification.tests.model_factories import (
+    CertifyingOrganisationF,
+    CreditsOrderF,
+    InvoiceF,
+)
+
+
+class InvoicePdfRenderTest(TestCase):
+    def setUp(self):
+        self.project = ProjectF.create()
+        self.organisation = CertifyingOrganisationF.create(project=self.project)
+        self.credits_order = CreditsOrderF.create(organisation=self.organisation)
+
+    def test_render_returns_pdf_bytes(self):
+        invoice = InvoiceF.create(credits_order=self.credits_order)
+        pdf_bytes = render_invoice_pdf(invoice)
+        self.assertIsInstance(pdf_bytes, (bytes, bytearray))
+        self.assertGreater(len(pdf_bytes), 0)
+        self.assertTrue(pdf_bytes.startswith(b'%PDF'))
+
+
+class CreateAndSendInvoiceTest(TestCase):
+    def setUp(self):
+        # ProjectF.create dedupes by name; set invoice fields after fetch.
+        self.project = ProjectF.create()
+        self.project.credit_cost = Decimal('10.00')
+        self.project.credit_cost_currency = 'EUR'
+        self.project.invoice_number_prefix = 'QGIS'
+        self.project.invoice_issuer_name = 'QGIS.ORG'
+        self.project.invoice_issuer_address = 'Issuer street 1\n1234 City'
+        self.project.save()
+        self.organisation = CertifyingOrganisationF.create(
+            project=self.project,
+            name='Test Org',
+            address='Org street 2',
+            organisation_email='org@example.com',
+            vat_number='ES-B12345678',
+        )
+        self.credits_order = CreditsOrderF.create(
+            organisation=self.organisation,
+            credits_requested=7,
+        )
+
+    def test_creates_invoice_with_billing_snapshot(self):
+        invoice = create_and_send_invoice(
+            self.credits_order, payrexx_transaction={'id': 'TX-1'})
+        self.assertIsNotNone(invoice)
+        self.assertEqual(invoice.billing_name, 'Test Org')
+        self.assertEqual(invoice.billing_vat_number, 'ES-B12345678')
+        self.assertEqual(invoice.issuer_name, 'QGIS.ORG')
+        self.assertEqual(invoice.quantity, 7)
+        self.assertEqual(invoice.unit_price, Decimal('10.00'))
+        self.assertEqual(invoice.subtotal, Decimal('70.00'))
+        self.assertEqual(invoice.total, Decimal('70.00'))
+        self.assertEqual(invoice.currency, 'EUR')
+        self.assertEqual(invoice.payment_reference, 'TX-1')
+        self.assertTrue(invoice.invoice_number.startswith('QGIS-'))
+        self.assertTrue(invoice.pdf)
+
+    def test_applies_tax_rate(self):
+        self.project.invoice_tax_rate = Decimal('21.00')
+        self.project.save()
+        invoice = create_and_send_invoice(self.credits_order)
+        self.assertEqual(invoice.subtotal, Decimal('70.00'))
+        self.assertEqual(invoice.tax_amount, Decimal('14.70'))
+        self.assertEqual(invoice.total, Decimal('84.70'))
+
+    def test_is_idempotent(self):
+        first = create_and_send_invoice(self.credits_order)
+        second = create_and_send_invoice(self.credits_order)
+        self.assertEqual(first.pk, second.pk)
+        self.assertEqual(Invoice.objects.filter(
+            credits_order=self.credits_order).count(), 1)

--- a/django_project/certification/tests/views/test_payrexx_webhook.py
+++ b/django_project/certification/tests/views/test_payrexx_webhook.py
@@ -1,0 +1,119 @@
+# coding=utf-8
+"""Integration tests for the Payrexx webhook -> invoice flow."""
+
+import json
+from decimal import Decimal
+from unittest import mock
+
+from django.core import mail
+from django.test import TestCase, override_settings
+from django.test.client import Client
+from django.urls import reverse
+from django.utils.translation import override as translation_override
+
+from base.tests.model_factories import ProjectF
+from certification.models.invoice import Invoice
+from certification.tests.model_factories import (
+    CertifyingOrganisationF,
+    CreditsOrderF,
+)
+from core.model_factories import UserF
+
+
+@override_settings(
+    VALID_DOMAIN=['testserver'],
+    EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend',
+)
+class PayrexxWebhookInvoiceTest(TestCase):
+    def setUp(self):
+        self.project = ProjectF.create()
+        self.project.credit_cost = Decimal('10.00')
+        self.project.credit_cost_currency = 'EUR'
+        self.project.invoice_number_prefix = 'QGIS'
+        self.project.invoice_issuer_name = 'QGIS.ORG'
+        self.project.invoice_issuer_address = 'Issuer street 1'
+        self.project.invoice_issuer_email = 'billing@qgis.org'
+        self.project.save()
+        self.owner = UserF.create(email='owner@example.com')
+        self.organisation = CertifyingOrganisationF.create(
+            project=self.project,
+            name='Webhook Org',
+            address='Webhook street',
+            organisation_email='org@example.com',
+            vat_number='ES-X',
+        )
+        self.organisation.organisation_owners.add(self.owner)
+        self.credits_order = CreditsOrderF.create(
+            organisation=self.organisation,
+            credits_requested=3,
+        )
+
+    def _post_webhook(self):
+        payload = {
+            'transaction': {
+                'id': 'TX-42',
+                'referenceId': self.credits_order.pk,
+            }
+        }
+        # Force the URL to use a supported language prefix ('en'); the
+        # default LANGUAGE_CODE 'en-us' is not in LANGUAGES so i18n_patterns
+        # would resolve it as a 404.
+        with translation_override('en'):
+            url = reverse('payrexx-webhook')
+        return Client().post(
+            url,
+            data=json.dumps(payload),
+            content_type='application/json',
+        )
+
+    @mock.patch('certification.views.payrexx.PayrexxService')
+    def test_webhook_creates_invoice_and_sends_email(self, mock_service):
+        mock_service.return_value.get_transaction.return_value = {
+            'status': 'confirmed',
+            'referenceId': self.credits_order.pk,
+            'id': 'TX-42',
+        }
+
+        response = self._post_webhook()
+        self.assertEqual(response.status_code, 200)
+
+        invoices = Invoice.objects.filter(credits_order=self.credits_order)
+        self.assertEqual(invoices.count(), 1)
+        invoice = invoices.get()
+        self.assertEqual(invoice.quantity, 3)
+        self.assertEqual(invoice.total, Decimal('30.00'))
+        self.assertTrue(invoice.pdf)
+
+        self.assertEqual(len(mail.outbox), 1)
+        sent = mail.outbox[0]
+        self.assertIn(invoice.invoice_number, sent.subject)
+        self.assertIn('owner@example.com', sent.to)
+        attachment_names = [att[0] for att in sent.attachments]
+        self.assertIn(f'{invoice.invoice_number}.pdf', attachment_names)
+        # Email is plain text only — no HTML alternative attached.
+        self.assertEqual(getattr(sent, 'alternatives', []), [])
+
+        # Organisation credits incremented.
+        self.organisation.refresh_from_db()
+        self.assertEqual(self.organisation.organisation_credits, 3)
+
+    @mock.patch('certification.views.payrexx.PayrexxService')
+    def test_webhook_replay_is_idempotent(self, mock_service):
+        mock_service.return_value.get_transaction.return_value = {
+            'status': 'confirmed',
+            'referenceId': self.credits_order.pk,
+            'id': 'TX-42',
+        }
+
+        self._post_webhook()
+        # Reset captured outbox to count only the second send (if any).
+        mail.outbox = []
+        response = self._post_webhook()
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(
+            Invoice.objects.filter(credits_order=self.credits_order).count(),
+            1,
+        )
+        # No second email — webhook detected credits already issued.
+        self.assertEqual(len(mail.outbox), 0)

--- a/django_project/certification/views/payrexx.py
+++ b/django_project/certification/views/payrexx.py
@@ -3,12 +3,12 @@ import logging
 from decimal import Decimal
 
 from base.models.project import Project
+from certification.invoice_utils import create_and_send_invoice
 from certification.mixins import ActiveCertifyingOrganisationRequiredMixin
 from certification.models.certifying_organisation import CertifyingOrganisation
 from certification.models.credits_order import CreditsOrder
 from certification.utilities import PayrexxService
 from django.conf import settings
-from django.core.mail import send_mail
 from django.http import Http404, HttpResponse, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -79,13 +79,32 @@ class PayrexxTopUpView(ActiveCertifyingOrganisationRequiredMixin, TemplateView):
       credit{'s' if total_credits > 1 else ''} \
       for {organisation.name}"
 
-        payrexx = PayrexxService()
-
         # Create a new CreditsOrder instance
         credits_order = CreditsOrder.objects.create(
             organisation=organisation,
             credits_requested=total_credits,
         )
+
+        if settings.DEBUG:
+            # Dev shortcut: skip the Payrexx round-trip, assume the payment
+            # succeeded, issue credits and email the invoice straight away
+            # so the flow can be exercised without real card processing.
+            organisation.organisation_credits = (
+                organisation.organisation_credits or 0
+            ) + total_credits
+            organisation.save()
+            credits_order.credits_issued = True
+            credits_order.save()
+            create_and_send_invoice(
+                credits_order,
+                payrexx_transaction={'id': f'DEBUG-{credits_order.pk}'},
+            )
+            return redirect(
+                'certifyingorganisation-detail',
+                slug=self.organisation_slug,
+            )
+
+        payrexx = PayrexxService()
 
         redirect_url = request.build_absolute_uri(
             reverse(
@@ -159,14 +178,9 @@ class PayrexxWebhookView(View):
         credits_order.credits_issued = True
         credits_order.save()
 
-        # Step 5: Send email to organisation owners
-        organisation_owners = organisation.organisation_owners.all()
-        send_mail(
-            subject=f"QGIS Certification: Credits Top Up for {organisation.name}",
-            message=f"Your organisation has been credited with {credits_order.credits_requested} credits.",
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            recipient_list=[owner.email for owner in organisation_owners],
-        )
+        # Step 5: Generate and email the invoice (PDF attached)
+        create_and_send_invoice(
+            credits_order, payrexx_transaction=verified_transation)
 
         # Step 6: Respond 200 OK
         return HttpResponse("Credits updated with success!", status=200)


### PR DESCRIPTION
Closes #101.

## What

Whenever an organisation successfully tops up credits, an Invoice record is created and a plain-text email with the PDF attached is sent to the organisation owners.

## Changes

- **Optional VAT/company number** on `CertifyingOrganisation`, shown in the form and on the invoice.
- **Invoice issuer settings** on `Project` (name, address, VAT, email, phone, bank details, number prefix, tax rate), prefilled with the QGIS template defaults. The existing `project.image_file` is reused as the invoice logo. We can always easily change the value of each field from the administration page later.
- New `Invoice` model with a frozen billing/issuer snapshot, sequential per-year numbering (`QGIS-YYYY-NNNN`), and a stored PDF. Registered in the admin.
- Plain-text email with the PDF attached, triggered from `PayrexxWebhookView` once credits are issued. Idempotent — webhook retries don't duplicate invoices or emails.

Cc @andreasneumann I will share an example of the automatically generate invoice with you.