### PR TITLE
Block deletion of courses/course types that contains valid certificates

### DIFF
--- a/django_project/certification/mixins.py
+++ b/django_project/certification/mixins.py
@@ -1,11 +1,56 @@
-from certification.models import CertifyingOrganisation
-from django.http import Http404
+from certification.models import CertifyingOrganisation, Course, CourseConvener
+from django.contrib import messages
+from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
+from django.core.exceptions import PermissionDenied
+from django.http import Http404, HttpRequest, HttpResponse
+from django.utils.translation import gettext_lazy as _
+
+# Views reach these mixins with either a signed-in user or an AnonymousUser,
+# and both are asked the same permission questions.
+UserOrAnonymous = AbstractBaseUser | AnonymousUser
+
+
+def user_can_manage_organisation(
+    user: UserOrAnonymous,
+    certifying_organisation: CertifyingOrganisation,
+) -> bool:
+    """Check whether a user may create, modify or delete objects of an
+    organisation.
+
+    This is the single source of truth for the rule that the templates
+    already express when they decide whether to show the edit and delete
+    buttons. Keep it in step with course/detail.html and
+    course_type/detail.html.
+
+    :param user: The user requesting the action.
+    :type user: User
+
+    :param certifying_organisation: The organisation owning the object.
+    :type certifying_organisation: CertifyingOrganisation
+
+    :returns: True if the user is allowed to manage the organisation.
+    :rtype: bool
+    """
+
+    if not user.is_authenticated:
+        return False
+    if user.is_staff:
+        return True
+
+    project = certifying_organisation.project
+    return (
+        certifying_organisation.organisation_owners.filter(pk=user.pk).exists()
+        or project.certification_managers.filter(pk=user.pk).exists()
+        or user == project.owner
+    )
 
 
 class ActiveCertifyingOrganisationRequiredMixin:
     """Mixin to ensure that the certifyin organisation is not archived."""
 
-    def dispatch(self, request, *args, **kwargs):
+    def dispatch(
+        self, request: HttpRequest, *args: object, **kwargs: object
+    ) -> HttpResponse:
         organisation_slug = kwargs.get("organisation_slug") or kwargs.get("slug")
         try:
             organisation = CertifyingOrganisation.objects.get(slug=organisation_slug)
@@ -14,3 +59,149 @@ class ActiveCertifyingOrganisationRequiredMixin:
         if organisation.is_archived:
             raise Http404("This organisation is archived.")
         return super().dispatch(request, *args, **kwargs)
+
+
+class OrganisationEditPermissionMixin:
+    """Enforce, on the server, who may modify an organisation's objects.
+
+    Until this existed the rule was applied only by hiding buttons in the
+    templates, which any user could bypass by requesting the URL directly.
+
+    The certifying organisation is resolved here, before ``get()`` and
+    ``post()`` run, so that permission is decided before the view touches
+    the object.
+    """
+
+    def get_permission_organisation(self) -> CertifyingOrganisation:
+        """Resolve the organisation this request acts on.
+
+        :returns: The certifying organisation named in the URL.
+        :rtype: CertifyingOrganisation
+        :raises: Http404
+        """
+
+        slug = self.kwargs.get("organisation_slug") or self.kwargs.get("slug")
+        try:
+            return CertifyingOrganisation.objects.get(slug=slug)
+        except CertifyingOrganisation.DoesNotExist:
+            raise Http404("Sorry! We could not find your certifying organisation!")
+
+    def user_has_edit_permission(
+        self,
+        user: UserOrAnonymous,
+        organisation: CertifyingOrganisation,
+    ) -> bool:
+        """Hook for subclasses that allow additional users.
+
+        :returns: True if the user may modify objects of this organisation.
+        :rtype: bool
+        """
+
+        return user_can_manage_organisation(user, organisation)
+
+    def dispatch(
+        self, request: HttpRequest, *args: object, **kwargs: object
+    ) -> HttpResponse:
+        organisation = self.get_permission_organisation()
+
+        # Make these available to get()/post()/get_queryset(), which several
+        # of these views set for themselves and then rely on.
+        self.organisation_slug = organisation.slug
+        self.certifying_organisation = organisation
+
+        if not self.user_has_edit_permission(request.user, organisation):
+            raise PermissionDenied(
+                _("You do not have permission to modify this organisation.")
+            )
+        return super().dispatch(request, *args, **kwargs)
+
+
+class CourseEditPermissionMixin(OrganisationEditPermissionMixin):
+    """Course permissions: as the organisation, plus course conveners.
+
+    The organisation detail page offers a convener the "Create New Course"
+    button and the course detail page offers them edit and delete, so both
+    cases are allowed here: creating a course anywhere in their organisation,
+    and changing a course they convene.
+    """
+
+    def user_has_edit_permission(
+        self,
+        user: UserOrAnonymous,
+        organisation: CertifyingOrganisation,
+    ) -> bool:
+        if super().user_has_edit_permission(user, organisation):
+            return True
+        if not user.is_authenticated:
+            return False
+
+        course_slug = self.kwargs.get("slug")
+        if course_slug is None:
+            # Creating: any convener of this organisation may add a course.
+            return CourseConvener.objects.filter(
+                certifying_organisation=organisation, user=user
+            ).exists()
+
+        # Looked up directly rather than through self.get_object(), which
+        # depends on attributes the view only sets once get()/post() runs.
+        return Course.objects.filter(
+            certifying_organisation=organisation,
+            slug=course_slug,
+            course_convener__user=user,
+        ).exists()
+
+
+class ProtectChildrenDeleteMixin:
+    """Refuse to delete an object while dependent records still exist.
+
+    The foreign keys pointing at Course and CourseType cascade, so deleting
+    a parent would take its children - including issued certificates - with
+    it. Rather than delete silently, the user is told what to remove first.
+
+    Note for Django >= 4.0: DeleteView deletes through FormMixin, so
+    ``delete()`` is no longer called on POST; the guard has to hook
+    ``post()``. Both delete views end their own ``post()`` with
+    ``super().post(...)``, so listing this mixin before DeleteView is enough
+    to run it.
+    """
+
+    def get_blocking_children(self) -> list[tuple[str, int]]:
+        """Describe the dependants that prevent deletion.
+
+        :returns: (label, count) for each non-empty relation.
+        :rtype: list
+        """
+
+        raise NotImplementedError(
+            "Subclasses of ProtectChildrenDeleteMixin must implement "
+            "get_blocking_children()."
+        )
+
+    def get_context_data(self, **kwargs: object) -> dict:
+        context = super().get_context_data(**kwargs)
+        if getattr(self, "object", None) is not None:
+            context["blocking_children"] = self.get_blocking_children()
+        return context
+
+    def get_blocked_message(
+        self, blocking_children: list[tuple[str, int]]
+    ) -> str:
+        """Build the message shown when deletion is refused."""
+
+        summary = ", ".join(
+            "%d %s" % (count, label) for label, count in blocking_children
+        )
+        return _(
+            "This %(object)s cannot be deleted because it still has "
+            "%(summary)s. Please remove them first."
+        ) % {"object": self.model._meta.verbose_name, "summary": summary}
+
+    def post(
+        self, request: HttpRequest, *args: object, **kwargs: object
+    ) -> HttpResponse:
+        self.object = self.get_object()
+        blocking_children = self.get_blocking_children()
+        if blocking_children:
+            messages.error(request, self.get_blocked_message(blocking_children))
+            return self.render_to_response(self.get_context_data(object=self.object))
+        return super().post(request, *args, **kwargs)

--- a/django_project/certification/models/certificate.py
+++ b/django_project/certification/models/certificate.py
@@ -3,6 +3,8 @@
 
 """
 
+import datetime
+
 from django.urls import reverse
 from django.db import models
 from django.contrib.auth.models import User
@@ -96,3 +98,28 @@ class Certificate(models.Model):
         return reverse('certificate-detail', kwargs={
             'slug': self.certificateID,
         })
+
+    #: Days after issue during which a certificate may still be revoked.
+    REVOCATION_WINDOW_DAYS = 7
+
+    @property
+    def is_revocable(self) -> bool:
+        """Whether this certificate may still be revoked.
+
+        Keyed to issue_date rather than the course end date. issue_date is
+        auto_now_add and read-only in the admin, so it cannot be moved;
+        Course.end_date is part of CourseForm, so keying the window to it
+        would let anyone who can edit a course reopen the window at will.
+
+        A certificate with no issue_date predates the field and is treated
+        as a permanent record.
+
+        :returns: True while the certificate is still within the window.
+        :rtype: bool
+        """
+
+        if not self.issue_date:
+            return False
+        window_closes = self.issue_date + datetime.timedelta(
+            days=self.REVOCATION_WINDOW_DAYS)
+        return window_closes > datetime.date.today()

--- a/django_project/certification/models/course.py
+++ b/django_project/certification/models/course.py
@@ -145,3 +145,24 @@ class Course(models.Model):
             return False
         else:
             return True
+
+    @property
+    def permanent_certificate_count(self) -> int:
+        """Certificates on this course that can no longer be revoked.
+
+        While this is above zero the course holds a permanent record and can
+        never be deleted, however many other children are removed first.
+
+        Iterates rather than filtering in SQL so that the window stays
+        defined in one place, Certificate.is_revocable. Callers dealing with
+        many courses should prefetch_related('certificate_set').
+
+        :returns: Number of certificates past their revocation window.
+        :rtype: int
+        """
+
+        return sum(
+            1
+            for certificate in self.certificate_set.all()
+            if not certificate.is_revocable
+        )

--- a/django_project/certification/templates/course/delete.html
+++ b/django_project/certification/templates/course/delete.html
@@ -12,7 +12,17 @@
 
 {% block content %}
     <form action="" id="delete-confirmation" method="post" class="box-content">{% csrf_token %}
-        {% if blocking_children %}
+        {% if permanent_certificate_count %}
+            <div class="notification is-danger is-light">
+                <p><strong>This course cannot be deleted.</strong></p>
+                <p>
+                    It holds {{ permanent_certificate_count }} certificate{{ permanent_certificate_count|pluralize }}
+                    that can no longer be revoked, because the 7 day
+                    revocation window has closed. Those certificates are a
+                    permanent record, so the course has to be kept.
+                </p>
+            </div>
+        {% elif blocking_children %}
             <div class="notification is-danger is-light">
                 <p><strong>This course cannot be deleted yet.</strong></p>
                 <p>It still has:</p>
@@ -22,9 +32,9 @@
                     {% endfor %}
                 </ul>
                 <p>
-                    Deleting it would also delete those records, including any
-                    certificates already issued. Please remove them first, then
-                    return here.
+                    Every certificate on this course can still be revoked, so
+                    you can remove these records first and then delete the
+                    course.
                 </p>
             </div>
         {% else %}

--- a/django_project/certification/templates/course/delete.html
+++ b/django_project/certification/templates/course/delete.html
@@ -12,9 +12,26 @@
 
 {% block content %}
     <form action="" id="delete-confirmation" method="post" class="box-content">{% csrf_token %}
-        <div class="notification is-danger is-light">
-            <p>Are you sure you want to delete the course below?</p>
-        </div>
+        {% if blocking_children %}
+            <div class="notification is-danger is-light">
+                <p><strong>This course cannot be deleted yet.</strong></p>
+                <p>It still has:</p>
+                <ul>
+                    {% for label, count in blocking_children %}
+                        <li>{{ count }} {{ label }}</li>
+                    {% endfor %}
+                </ul>
+                <p>
+                    Deleting it would also delete those records, including any
+                    certificates already issued. Please remove them first, then
+                    return here.
+                </p>
+            </div>
+        {% else %}
+            <div class="notification is-danger is-light">
+                <p>Are you sure you want to delete the course below?</p>
+            </div>
+        {% endif %}
         <div>
             <h3 class="title is-4">Course: {{ course.name }}</h3>
             <div class="columns">
@@ -29,6 +46,7 @@
             </div>
         </div>
         <div class="buttons is-right">
+            {% if not blocking_children %}
             <a class="button is-danger"
                href="#"
                onClick="document.getElementById('delete-confirmation').submit()"
@@ -38,6 +56,7 @@
                 </span>
                 <span>Delete</span>
             </a>
+            {% endif %}
             <a class="button is-light"
                href='{% url "certifyingorganisation-detail" slug=course.certifying_organisation.slug %}'
                title="Cancel">

--- a/django_project/certification/templates/course/detail.html
+++ b/django_project/certification/templates/course/detail.html
@@ -279,6 +279,7 @@
                                         {% endif %}
                                         {% if attendee.attendee.pk in certificates %}
                                         {% if attendee.attendee.pk in paid_certificates %}
+                                        {# attendee.editable is Certificate.is_revocable, the rule CertificateRevokeView enforces. #}
                                         {% if attendee.editable %}
                                         <a class="button is-small is-light has-tooltip-multiline has-tooltip-arrow has-tooltip-bottom" data-tooltip="Revoke Certificate" href='{% url "revoke-certificate" organisation_slug=course.certifying_organisation.slug course_slug=course.slug pk=attendee.attendee.pk %}'>
                                             <span class="icon is-small">
@@ -286,7 +287,7 @@
                                             </span>
                                         </a>
                                         {% else %}
-                                        <a class="button is-small is-light has-tooltip-multiline has-tooltip-arrow has-tooltip-bottom" data-tooltip="Revoke Certificate is only available 7 days after the certificate is issued." href="#" disabled>
+                                        <a class="button is-small is-light has-tooltip-multiline has-tooltip-arrow has-tooltip-bottom" data-tooltip="Certificates can only be revoked within 7 days of being issued. This one is now a permanent record." href="#" disabled>
                                             <span class="icon is-small">
                                                 <i class="fas fa-exclamation-triangle"></i>
                                             </span>

--- a/django_project/certification/templates/course_type/delete.html
+++ b/django_project/certification/templates/course_type/delete.html
@@ -12,7 +12,19 @@
 
 {% block content %}
     <form action="" id="delete-confirmation" method="post" class="box-content">{% csrf_token %}
-        {% if blocking_children %}
+        {% if blocked_course_count %}
+            <div class="notification is-danger is-light">
+                <p><strong>This course type cannot be deleted.</strong></p>
+                <p>
+                    {{ blocked_course_count }} of its course{{ blocked_course_count|pluralize }}
+                    hold{{ blocked_course_count|pluralize:"s," }} certificates
+                    that can no longer be revoked, because the 7 day
+                    revocation window has closed. Those courses are a
+                    permanent record and cannot be deleted, so neither can
+                    this course type.
+                </p>
+            </div>
+        {% elif blocking_children %}
             <div class="notification is-danger is-light">
                 <p><strong>This course type cannot be deleted yet.</strong></p>
                 <p>It is still used by:</p>
@@ -22,9 +34,8 @@
                     {% endfor %}
                 </ul>
                 <p>
-                    Deleting it would also delete those courses and every
-                    certificate issued for them. Please delete each course
-                    first, then return here.
+                    Every certificate on those courses can still be revoked,
+                    so you can delete each course first and then return here.
                 </p>
             </div>
         {% else %}

--- a/django_project/certification/templates/course_type/delete.html
+++ b/django_project/certification/templates/course_type/delete.html
@@ -12,9 +12,26 @@
 
 {% block content %}
     <form action="" id="delete-confirmation" method="post" class="box-content">{% csrf_token %}
-        <div class="notification is-danger is-light">
-            <p >Are you sure you want to delete the course type below?</p>
-        </div>
+        {% if blocking_children %}
+            <div class="notification is-danger is-light">
+                <p><strong>This course type cannot be deleted yet.</strong></p>
+                <p>It is still used by:</p>
+                <ul>
+                    {% for label, count in blocking_children %}
+                        <li>{{ count }} {{ label }}</li>
+                    {% endfor %}
+                </ul>
+                <p>
+                    Deleting it would also delete those courses and every
+                    certificate issued for them. Please delete each course
+                    first, then return here.
+                </p>
+            </div>
+        {% else %}
+            <div class="notification is-danger is-light">
+                <p >Are you sure you want to delete the course type below?</p>
+            </div>
+        {% endif %}
         <div>
             <h3 class="title is-4">Course Type: {{ coursetype.name }}</h3>
             <div class="columns">
@@ -26,6 +43,7 @@
             </div>
         </div>
         <div class="buttons is-right">
+            {% if not blocking_children %}
             <a class="button is-danger"
                href="#"
                onClick="document.getElementById('delete-confirmation').submit()"
@@ -35,6 +53,7 @@
             </span>
             <span>Delete</span>
             </a>
+            {% endif %}
             <a class="button is-light"
                href='{% url "certifyingorganisation-detail" coursetype.certifying_organisation.slug %}'
                title="Cancel">

--- a/django_project/certification/templates/course_type/detail.html
+++ b/django_project/certification/templates/course_type/detail.html
@@ -21,7 +21,7 @@
         {# Only organisation owners, project owner or staff can edit #}
         <div class="column is-narrow">
             <div class="buttons">
-                {% if user in certifyingorganisation.organisation_owners.all or user.is_staff or user == project.owner or user in project.certification_manager.all %}
+                {% if user in coursetype.certifying_organisation.organisation_owners.all or user.is_staff or user == project.owner or user in project.certification_managers.all %}
                 <a class="button is-danger is-outlined has-tooltip-bottom has-tooltip-arrow"
                    href='{% url "coursetype-delete" organisation_slug=coursetype.certifying_organisation.slug pk=coursetype.pk %}'
                    data-tooltip="Delete {{ coursetype.name }}">

--- a/django_project/certification/tests/views/test_certificate_revoke.py
+++ b/django_project/certification/tests/views/test_certificate_revoke.py
@@ -1,0 +1,197 @@
+# coding=utf-8
+"""Tests for revoking a certificate: the 7 day window and the credit refund."""
+
+import datetime
+import logging
+
+from certification.models import Certificate, CertifyingOrganisation
+from certification.tests.model_factories import (
+    AttendeeF,
+    CertificateF,
+    CertificateTypeF,
+    CertifyingOrganisationF,
+    CourseConvenerF,
+    CourseF,
+    CourseTypeF,
+    ProjectF,
+    TrainingCenterF,
+    UserF,
+)
+from django.test import TestCase, override_settings
+from django.test.client import Client
+from django.urls import reverse
+
+
+@override_settings(VALID_DOMAIN=['testserver', ])
+class CertificateRevokeTestBase(TestCase):
+    """One organisation with a paid certificate ready to revoke."""
+
+    def setUp(self) -> None:
+        self.client = Client()
+        self.client.post('/set_language/', data={'language': 'en'})
+        logging.disable(logging.CRITICAL)
+
+        self.project = ProjectF.create()
+        self.project.certificate_credit = 5
+        self.project.save()
+
+        self.organisation = CertifyingOrganisationF.create(
+            project=self.project)
+        self.organisation.organisation_credits = 10
+        self.organisation.save()
+
+        self.user = UserF.create(username='staff', is_staff=True)
+        self.user.set_password('password')
+        self.user.save()
+
+        self.course = CourseF.create(
+            certifying_organisation=self.organisation,
+            training_center=TrainingCenterF.create(
+                certifying_organisation=self.organisation),
+            course_convener=CourseConvenerF.create(
+                certifying_organisation=self.organisation),
+            course_type=CourseTypeF.create(
+                certifying_organisation=self.organisation),
+        )
+        self.attendee = AttendeeF.create(
+            certifying_organisation=self.organisation)
+        self.certificate = CertificateF.create(
+            course=self.course,
+            attendee=self.attendee,
+            certificate_type=CertificateTypeF.create(),
+        )
+
+    def set_issue_date(self, days_ago: int) -> None:
+        """Move the certificate issue date, which opens or closes the window.
+
+        issue_date is auto_now_add, so it has to be written with an update()
+        rather than through save().
+        """
+
+        Certificate.objects.filter(pk=self.certificate.pk).update(
+            issue_date=datetime.date.today() - datetime.timedelta(
+                days=days_ago))
+        self.certificate.refresh_from_db()
+
+    def clear_issue_date(self) -> None:
+        """Legacy certificates have no issue date at all."""
+
+        Certificate.objects.filter(pk=self.certificate.pk).update(
+            issue_date=None)
+        self.certificate.refresh_from_db()
+
+    def revoke_url(self) -> str:
+        return reverse('revoke-certificate', kwargs={
+            'organisation_slug': self.organisation.slug,
+            'course_slug': self.course.slug,
+            'pk': self.attendee.pk,
+        })
+
+    def organisation_credits(self) -> int:
+        return CertifyingOrganisation.objects.get(
+            pk=self.organisation.pk).organisation_credits
+
+
+class TestRevokeWindow(CertificateRevokeTestBase):
+    """The window is enforced on POST, not only on GET."""
+
+    def test_revoke_allowed_inside_window(self) -> None:
+        self.set_issue_date(days_ago=1)
+        self.client.login(username='staff', password='password')
+
+        response = self.client.post(self.revoke_url())
+
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(
+            Certificate.objects.filter(pk=self.certificate.pk).exists())
+
+    def test_post_is_refused_outside_window(self) -> None:
+        """Enforcing on GET alone left the window bypassable by POSTing."""
+
+        self.set_issue_date(days_ago=90)
+        self.client.login(username='staff', password='password')
+
+        response = self.client.post(self.revoke_url())
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(
+            Certificate.objects.filter(pk=self.certificate.pk).exists())
+
+    def test_get_is_refused_outside_window(self) -> None:
+        self.set_issue_date(days_ago=90)
+        self.client.login(username='staff', password='password')
+
+        response = self.client.get(self.revoke_url())
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(
+            Certificate.objects.filter(pk=self.certificate.pk).exists())
+
+    def test_refusal_redirects_to_the_course(self) -> None:
+        """A readable page, rather than the bare 403 text it used to return."""
+
+        self.set_issue_date(days_ago=90)
+        self.client.login(username='staff', password='password')
+
+        response = self.client.get(self.revoke_url())
+
+        self.assertRedirects(response, reverse('course-detail', kwargs={
+            'organisation_slug': self.organisation.slug,
+            'slug': self.course.slug,
+        }))
+
+
+    def test_certificate_without_issue_date_is_permanent(self) -> None:
+        """Legacy rows predating issue_date are kept, not revocable."""
+
+        self.clear_issue_date()
+        self.client.login(username='staff', password='password')
+
+        response = self.client.post(self.revoke_url())
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(
+            Certificate.objects.filter(pk=self.certificate.pk).exists())
+
+    def test_moving_the_course_end_date_does_not_reopen_the_window(self) -> None:
+        """end_date is user-editable, so it must not govern revocation.
+
+        Keying the window to the course end date would let anyone who can
+        edit a course reopen revocation indefinitely.
+        """
+
+        self.set_issue_date(days_ago=90)
+        self.course.end_date = datetime.date.today()
+        self.course.save()
+
+        self.client.login(username='staff', password='password')
+        response = self.client.post(self.revoke_url())
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(
+            Certificate.objects.filter(pk=self.certificate.pk).exists())
+
+
+class TestRevokeRefundsCredit(CertificateRevokeTestBase):
+    """The refund lived in delete(), which Django 4 never calls."""
+
+    def test_revoking_refunds_the_certificate_credit(self) -> None:
+        self.set_issue_date(days_ago=1)
+        credits_before = self.organisation_credits()
+
+        self.client.login(username='staff', password='password')
+        self.client.post(self.revoke_url())
+
+        self.assertEqual(
+            self.organisation_credits(),
+            credits_before + self.project.certificate_credit,
+        )
+
+    def test_refused_revocation_does_not_refund(self) -> None:
+        self.set_issue_date(days_ago=90)
+        credits_before = self.organisation_credits()
+
+        self.client.login(username='staff', password='password')
+        self.client.post(self.revoke_url())
+
+        self.assertEqual(self.organisation_credits(), credits_before)

--- a/django_project/certification/tests/views/test_course_permissions.py
+++ b/django_project/certification/tests/views/test_course_permissions.py
@@ -3,6 +3,7 @@
 protect courses and course types from cascading deletions."""
 
 import logging
+from datetime import date, timedelta
 
 from certification.models import Certificate, Course, CourseType
 from certification.tests.model_factories import (
@@ -273,6 +274,57 @@ class TestCourseDeleteGuard(CoursePermissionTestBase):
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue(Course.objects.filter(pk=self.course.pk).exists())
+
+    def issue_certificate(self, issued_days_ago: int) -> Certificate:
+        """Attach a certificate with a back-dated issue date.
+
+        issue_date is auto_now_add, so it has to be written with update().
+        """
+
+        certificate = CertificateF.create(
+            course=self.course,
+            attendee=AttendeeF.create(
+                certifying_organisation=self.certifying_organisation),
+            certificate_type=CertificateTypeF.create(),
+        )
+        Certificate.objects.filter(pk=certificate.pk).update(
+            issue_date=date.today() - timedelta(days=issued_days_ago))
+        return certificate
+
+    def test_message_says_never_when_a_certificate_is_permanent(self) -> None:
+        """Past the window there is no sequence of steps that frees the course."""
+
+        self.issue_certificate(issued_days_ago=90)
+
+        self.login('staff')
+        response = self.client.get(self.course_delete_url())
+
+        self.assertContains(response, 'This course cannot be deleted.')
+        self.assertContains(response, 'can no longer be revoked')
+        self.assertNotContains(response, 'cannot be deleted yet')
+
+    def test_message_says_not_yet_when_all_certificates_are_revocable(
+            self) -> None:
+        self.issue_certificate(issued_days_ago=1)
+
+        self.login('staff')
+        response = self.client.get(self.course_delete_url())
+
+        self.assertContains(response, 'This course cannot be deleted yet.')
+        self.assertContains(response, 'can still be revoked')
+        self.assertNotContains(response, 'permanent record')
+
+    def test_one_permanent_certificate_is_enough_to_block_forever(self) -> None:
+        """A mix of revocable and permanent still means permanent."""
+
+        self.issue_certificate(issued_days_ago=1)
+        self.issue_certificate(issued_days_ago=90)
+
+        self.login('staff')
+        response = self.client.get(self.course_delete_url())
+
+        self.assertContains(response, 'This course cannot be deleted.')
+        self.assertNotContains(response, 'cannot be deleted yet')
 
     def test_delete_succeeds_when_course_has_no_children(self) -> None:
         self.login('staff')

--- a/django_project/certification/tests/views/test_course_permissions.py
+++ b/django_project/certification/tests/views/test_course_permissions.py
@@ -1,0 +1,282 @@
+# coding=utf-8
+"""Tests for the server-side permission checks and the delete guards that
+protect courses and course types from cascading deletions."""
+
+import logging
+
+from certification.models import Certificate, Course, CourseType
+from certification.tests.model_factories import (
+    AttendeeF,
+    CertificateF,
+    CertificateTypeF,
+    CertifyingOrganisationF,
+    CourseAttendeeF,
+    CourseConvenerF,
+    CourseF,
+    CourseTypeF,
+    ProjectF,
+    TrainingCenterF,
+    UserF,
+)
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+from django.test.client import Client
+from django.urls import reverse
+
+
+@override_settings(VALID_DOMAIN=['testserver', ])
+class CoursePermissionTestBase(TestCase):
+    """Shared fixtures: one organisation, one course and a cast of users."""
+
+    def setUp(self) -> None:
+        self.client = Client()
+        self.client.post('/set_language/', data={'language': 'en'})
+        logging.disable(logging.CRITICAL)
+
+        self.project = ProjectF.create()
+        self.certifying_organisation = CertifyingOrganisationF.create(
+            project=self.project
+        )
+        self.training_center = TrainingCenterF.create(
+            certifying_organisation=self.certifying_organisation)
+        self.course_convener = CourseConvenerF.create(
+            certifying_organisation=self.certifying_organisation)
+        self.course_type = CourseTypeF.create(
+            certifying_organisation=self.certifying_organisation)
+        self.course = CourseF.create(
+            certifying_organisation=self.certifying_organisation,
+            training_center=self.training_center,
+            course_convener=self.course_convener,
+            course_type=self.course_type,
+        )
+
+        self.outsider = self.make_user('outsider')
+        self.staff = self.make_user('staff', is_staff=True)
+        self.owner = self.make_user('owner')
+        self.certifying_organisation.organisation_owners.add(self.owner)
+
+        # The convener is a user in their own right and may edit their course.
+        self.convener_user = self.course_convener.user
+        self.convener_user.set_password('password')
+        self.convener_user.save()
+
+    def make_user(self, username: str, **kwargs: object) -> User:
+        user = UserF.create(username=username, **kwargs)
+        user.set_password('password')
+        user.save()
+        return user
+
+    def login(self, username: str) -> None:
+        self.assertTrue(
+            self.client.login(username=username, password='password'))
+
+    def course_delete_url(self) -> str:
+        return reverse('course-delete', kwargs={
+            'organisation_slug': self.certifying_organisation.slug,
+            'slug': self.course.slug,
+        })
+
+    def course_update_url(self) -> str:
+        return reverse('course-update', kwargs={
+            'organisation_slug': self.certifying_organisation.slug,
+            'slug': self.course.slug,
+        })
+
+    def coursetype_delete_url(self) -> str:
+        return reverse('coursetype-delete', kwargs={
+            'organisation_slug': self.certifying_organisation.slug,
+            'pk': self.course_type.pk,
+        })
+
+    def coursetype_update_url(self) -> str:
+        return reverse('coursetype-update', kwargs={
+            'organisation_slug': self.certifying_organisation.slug,
+            'pk': self.course_type.pk,
+        })
+
+
+class TestCoursePermissions(CoursePermissionTestBase):
+    """Only staff, organisation owners and the convener may modify a course."""
+
+    def test_outsider_cannot_get_course_delete(self) -> None:
+        self.login('outsider')
+        response = self.client.get(self.course_delete_url())
+        self.assertEqual(response.status_code, 403)
+
+    def test_outsider_cannot_post_course_delete(self) -> None:
+        """POSTing directly is the hole a hidden button does not close."""
+
+        self.login('outsider')
+        response = self.client.post(self.course_delete_url())
+        self.assertEqual(response.status_code, 403)
+        self.assertTrue(Course.objects.filter(pk=self.course.pk).exists())
+
+    def test_outsider_cannot_post_course_update(self) -> None:
+        self.login('outsider')
+        response = self.client.post(self.course_update_url(), data={})
+        self.assertEqual(response.status_code, 403)
+
+    def test_outsider_cannot_post_coursetype_update(self) -> None:
+        """CourseTypeUpdateView used to expose CourseType.objects.all()."""
+
+        self.login('outsider')
+        response = self.client.post(self.coursetype_update_url(), data={})
+        self.assertEqual(response.status_code, 403)
+
+    def test_outsider_cannot_post_coursetype_delete(self) -> None:
+        self.login('outsider')
+        response = self.client.post(self.coursetype_delete_url())
+        self.assertEqual(response.status_code, 403)
+        self.assertTrue(
+            CourseType.objects.filter(pk=self.course_type.pk).exists())
+
+    def test_staff_may_open_course_delete(self) -> None:
+        self.login('staff')
+        response = self.client.get(self.course_delete_url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_organisation_owner_may_open_course_delete(self) -> None:
+        self.login('owner')
+        response = self.client.get(self.course_delete_url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_convener_may_open_course_delete(self) -> None:
+        self.login(self.convener_user.username)
+        response = self.client.get(self.course_delete_url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_outsider_cannot_open_course_create(self) -> None:
+        self.login('outsider')
+        response = self.client.get(reverse('course-create', kwargs={
+            'organisation_slug': self.certifying_organisation.slug,
+        }))
+        self.assertEqual(response.status_code, 403)
+
+    def test_convener_may_open_course_create(self) -> None:
+        """The organisation detail page offers conveners this button."""
+
+        self.login(self.convener_user.username)
+        response = self.client.get(reverse('course-create', kwargs={
+            'organisation_slug': self.certifying_organisation.slug,
+        }))
+        self.assertEqual(response.status_code, 200)
+
+    def test_outsider_cannot_open_coursetype_create(self) -> None:
+        self.login('outsider')
+        response = self.client.get(reverse('coursetype-create', kwargs={
+            'organisation_slug': self.certifying_organisation.slug,
+        }))
+        self.assertEqual(response.status_code, 403)
+
+    def test_owner_may_open_coursetype_create(self) -> None:
+        self.login('owner')
+        response = self.client.get(reverse('coursetype-create', kwargs={
+            'organisation_slug': self.certifying_organisation.slug,
+        }))
+        self.assertEqual(response.status_code, 200)
+
+    def test_convener_may_not_delete_another_organisations_course(self) -> None:
+        """The convener exception is scoped to their own course."""
+
+        other_organisation = CertifyingOrganisationF.create(
+            project=self.project)
+        # Every related object is passed explicitly: the sub-factories would
+        # otherwise build a second Project, whose name is unique.
+        other_course = CourseF.create(
+            certifying_organisation=other_organisation,
+            course_type=CourseTypeF.create(
+                certifying_organisation=other_organisation),
+            training_center=TrainingCenterF.create(
+                certifying_organisation=other_organisation),
+            course_convener=CourseConvenerF.create(
+                certifying_organisation=other_organisation),
+        )
+        self.login(self.convener_user.username)
+        response = self.client.post(reverse('course-delete', kwargs={
+            'organisation_slug': other_organisation.slug,
+            'slug': other_course.slug,
+        }))
+        self.assertEqual(response.status_code, 403)
+        self.assertTrue(Course.objects.filter(pk=other_course.pk).exists())
+
+
+class TestCourseTypeDeleteGuard(CoursePermissionTestBase):
+    """A course type with courses must not be deletable."""
+
+    def test_delete_blocked_while_course_exists(self) -> None:
+        self.login('staff')
+        response = self.client.post(self.coursetype_delete_url())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            CourseType.objects.filter(pk=self.course_type.pk).exists())
+        self.assertTrue(Course.objects.filter(pk=self.course.pk).exists())
+        self.assertContains(response, 'cannot be deleted yet')
+
+    def test_deleting_course_type_never_removes_certificates(self) -> None:
+        """The regression this whole change exists to prevent."""
+
+        attendee = AttendeeF.create(
+            certifying_organisation=self.certifying_organisation)
+        CertificateF.create(
+            course=self.course,
+            attendee=attendee,
+            certificate_type=CertificateTypeF.create(),
+        )
+        certificates_before = Certificate.objects.count()
+
+        self.login('staff')
+        self.client.post(self.coursetype_delete_url())
+
+        self.assertEqual(Certificate.objects.count(), certificates_before)
+
+    def test_delete_succeeds_once_courses_are_removed(self) -> None:
+        """The guard defers deletion, it does not forbid it forever."""
+
+        self.course.delete()
+
+        self.login('staff')
+        response = self.client.post(self.coursetype_delete_url())
+
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(
+            CourseType.objects.filter(pk=self.course_type.pk).exists())
+
+
+class TestCourseDeleteGuard(CoursePermissionTestBase):
+    """A course holding certificates or attendees must not be deletable."""
+
+    def test_delete_blocked_by_certificate(self) -> None:
+        attendee = AttendeeF.create(
+            certifying_organisation=self.certifying_organisation)
+        CertificateF.create(
+            course=self.course,
+            attendee=attendee,
+            certificate_type=CertificateTypeF.create(),
+        )
+
+        self.login('staff')
+        response = self.client.post(self.course_delete_url())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(Course.objects.filter(pk=self.course.pk).exists())
+        self.assertEqual(Certificate.objects.count(), 1)
+        self.assertContains(response, 'cannot be deleted yet')
+
+    def test_delete_blocked_by_course_attendee(self) -> None:
+        attendee = AttendeeF.create(
+            certifying_organisation=self.certifying_organisation)
+        CourseAttendeeF.create(course=self.course, attendee=attendee)
+
+        self.login('staff')
+        response = self.client.post(self.course_delete_url())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(Course.objects.filter(pk=self.course.pk).exists())
+
+    def test_delete_succeeds_when_course_has_no_children(self) -> None:
+        self.login('staff')
+        response = self.client.post(self.course_delete_url())
+
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(Course.objects.filter(pk=self.course.pk).exists())

--- a/django_project/certification/tests/views/test_course_permissions.py
+++ b/django_project/certification/tests/views/test_course_permissions.py
@@ -231,6 +231,50 @@ class TestCourseTypeDeleteGuard(CoursePermissionTestBase):
 
         self.assertEqual(Certificate.objects.count(), certificates_before)
 
+    def issue_certificate_on_course(self, issued_days_ago: int) -> None:
+        """Attach a back-dated certificate to this course type's course."""
+
+        certificate = CertificateF.create(
+            course=self.course,
+            attendee=AttendeeF.create(
+                certifying_organisation=self.certifying_organisation),
+            certificate_type=CertificateTypeF.create(),
+        )
+        Certificate.objects.filter(pk=certificate.pk).update(
+            issue_date=date.today() - timedelta(days=issued_days_ago))
+
+    def test_message_says_never_when_a_course_is_permanent(self) -> None:
+        """Surfaced here so the user does not walk each course to find out."""
+
+        self.issue_certificate_on_course(issued_days_ago=90)
+
+        self.login('staff')
+        response = self.client.get(self.coursetype_delete_url())
+
+        self.assertContains(response, 'This course type cannot be deleted.')
+        self.assertContains(response, 'can no longer be revoked')
+        self.assertNotContains(response, 'cannot be deleted yet')
+
+    def test_message_says_not_yet_when_courses_are_still_removable(
+            self) -> None:
+        self.issue_certificate_on_course(issued_days_ago=1)
+
+        self.login('staff')
+        response = self.client.get(self.coursetype_delete_url())
+
+        self.assertContains(
+            response, 'This course type cannot be deleted yet.')
+        self.assertContains(response, 'can still be revoked')
+        self.assertNotContains(response, 'permanent record')
+
+    def test_message_says_not_yet_when_course_has_no_certificates(
+            self) -> None:
+        self.login('staff')
+        response = self.client.get(self.coursetype_delete_url())
+
+        self.assertContains(
+            response, 'This course type cannot be deleted yet.')
+
     def test_delete_succeeds_once_courses_are_removed(self) -> None:
         """The guard defers deletion, it does not forbid it forever."""
 

--- a/django_project/certification/views/attendee.py
+++ b/django_project/certification/views/attendee.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 import io
 import csv
-from datetime import timedelta, datetime
 
 from django.db import transaction
 from django.http import HttpResponseForbidden
@@ -306,11 +305,6 @@ class AttendeeUpdateView(LoginRequiredMixin, UpdateView):
             course=course,
             attendee=self.get_object()
         ).first()
-        if certificate:
-            if (
-                not certificate.issue_date or
-                certificate.issue_date +
-                    timedelta(days=7) <= datetime.today().date()
-            ):
-                return HttpResponseForbidden('Course is not editable.')
+        if certificate and not certificate.is_revocable:
+            return HttpResponseForbidden('Course is not editable.')
         return super(AttendeeUpdateView, self).get(request, *args, **kwargs)

--- a/django_project/certification/views/certificate.py
+++ b/django_project/certification/views/certificate.py
@@ -1263,9 +1263,6 @@ class CertificateRevokeView(
         self.pk = self.kwargs.get('pk', None)
         self.course = Course.objects.get(slug=self.course_slug)
 
-        if not self.course.editable:
-            return HttpResponseForbidden('Course is not editable.')
-
         return super(
             CertificateRevokeView, self).get(request, *args, **kwargs)
 
@@ -1292,6 +1289,51 @@ class CertificateRevokeView(
 
         return super(
             CertificateRevokeView, self).post(request, *args, **kwargs)
+
+    def dispatch(self, request, *args, **kwargs):
+        """Refuse revocation once the certificate's 7 day window has closed.
+
+        This is checked here rather than in get(), so that it covers POST as
+        well: enforcing it on GET alone left the window bypassable by posting
+        to the URL directly.
+        """
+
+        course_slug = self.kwargs.get('course_slug', None)
+        try:
+            course = Course.objects.get(slug=course_slug)
+        except Course.DoesNotExist:
+            raise Http404('Sorry! We could not find your course!')
+
+        certificate = Certificate.objects.filter(
+            course=course, attendee__pk=self.kwargs.get('pk')
+        ).first()
+
+        if certificate and not certificate.is_revocable:
+            if certificate.issue_date:
+                reason = _(
+                    'Certificates can only be revoked within %(days)s days of '
+                    'being issued, and this one was issued on %(issued)s.'
+                ) % {
+                    'days': Certificate.REVOCATION_WINDOW_DAYS,
+                    'issued': certificate.issue_date,
+                }
+            else:
+                reason = _(
+                    'This certificate has no recorded issue date and is kept '
+                    'as a permanent record.'
+                )
+            messages.error(
+                request,
+                _('This certificate can no longer be revoked. %(reason)s')
+                % {'reason': reason}
+            )
+            return HttpResponseRedirect(reverse('course-detail', kwargs={
+                'organisation_slug': self.kwargs.get('organisation_slug'),
+                'slug': course_slug,
+            }))
+
+        return super(
+            CertificateRevokeView, self).dispatch(request, *args, **kwargs)
 
     def get_success_url(self):
         """Define the redirect URL.
@@ -1321,7 +1363,14 @@ class CertificateRevokeView(
         qs = Certificate.objects.filter(course=self.course)
         return qs
 
-    def delete(self, request, *args, **kwargs):
+    def form_valid(self, form):
+        """Refund the credit and remove the PDF, then delete the certificate.
+
+        This logic used to live in delete(). Since Django 4.0 DeleteView
+        deletes through FormMixin and never calls delete(), so none of it was
+        running: revoking a certificate silently failed to refund the
+        organisation and left the generated PDF on disk.
+        """
 
         # Update organisation credits every time a certificate is revoked.
         organisation = \
@@ -1333,8 +1382,8 @@ class CertificateRevokeView(
         organisation.organisation_credits = remaining_credits
         organisation.save()
 
-        # Delete existing certificate
-        certificate = self.get_object()
+        # Remove the rendered certificate so a revoked ID cannot be served.
+        certificate = self.object
         filename = "{}.{}".format(certificate.certificateID, "pdf")
         project_folder = (
             organisation.project.name.lower()).replace(' ', '_')
@@ -1347,7 +1396,7 @@ class CertificateRevokeView(
             os.remove(pathname)
 
         return super(
-            CertificateRevokeView, self).delete(request, *args, **kwargs)
+            CertificateRevokeView, self).form_valid(form)
 
 
 class CheckoutSessionSuccessView(TemplateView):

--- a/django_project/certification/views/course.py
+++ b/django_project/certification/views/course.py
@@ -3,10 +3,15 @@ from datetime import datetime, timedelta
 
 from base.models import Project
 from braces.views import LoginRequiredMixin
-from certification.mixins import ActiveCertifyingOrganisationRequiredMixin
+from certification.mixins import (
+    ActiveCertifyingOrganisationRequiredMixin,
+    CourseEditPermissionMixin,
+    ProtectChildrenDeleteMixin,
+)
 from certification.utilities import check_slug
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import IntegrityError
+from django.db.models import QuerySet
 from django.http import Http404, HttpResponseRedirect
 from django.urls import reverse
 from django.views.generic import CreateView, DeleteView, DetailView, UpdateView
@@ -25,6 +30,7 @@ class CourseMixin(object):
 class CourseCreateView(
     LoginRequiredMixin,
     ActiveCertifyingOrganisationRequiredMixin,
+    CourseEditPermissionMixin,
     CourseMixin,
     CreateView,
 ):
@@ -93,6 +99,7 @@ class CourseCreateView(
 class CourseUpdateView(
     LoginRequiredMixin,
     ActiveCertifyingOrganisationRequiredMixin,
+    CourseEditPermissionMixin,
     CourseMixin,
     UpdateView,
 ):
@@ -181,16 +188,20 @@ class CourseUpdateView(
         context["project_slug"] = "qgis"
         return context
 
-    def get_queryset(self):
+    def get_queryset(self) -> QuerySet[Course]:
         """Get the queryset for this view.
-            In front end, only staff, organisation owners and course convener
-            can see the edit button.
 
-        :returns: All Course objects
+        Scoped to the organisation in the URL so a course cannot be edited
+        through another organisation's address. Who may edit it is decided
+        by CourseEditPermissionMixin.
+
+        :returns: Course queryset filtered by Certifying Organisation
         :rtype: QuerySet
         """
 
-        qs = Course.objects.all()
+        qs = Course.objects.filter(
+            certifying_organisation=self.certifying_organisation
+        )
         return qs
 
     def get_success_url(self):
@@ -265,13 +276,40 @@ class CourseUpdateView(
 
 
 class CourseDeleteView(
-    LoginRequiredMixin, ActiveCertifyingOrganisationRequiredMixin, DeleteView
+    LoginRequiredMixin,
+    ActiveCertifyingOrganisationRequiredMixin,
+    CourseEditPermissionMixin,
+    ProtectChildrenDeleteMixin,
+    DeleteView,
 ):
     """Delete view for Course."""
 
     model = Course
     context_object_name = "course"
     template_name = "course/delete.html"
+
+    def get_blocking_children(self) -> list[tuple[str, int]]:
+        """Certificates and course attendees both cascade from a course, so
+        either one protects it from deletion.
+
+        :returns: (label, count) for each non-empty relation.
+        :rtype: list
+        """
+
+        blocking_children = []
+        certificate_count = self.object.certificate_set.count()
+        if certificate_count:
+            blocking_children.append(
+                ("certificate" if certificate_count == 1 else "certificates",
+                 certificate_count)
+            )
+        attendee_count = self.object.courseattendee_set.count()
+        if attendee_count:
+            blocking_children.append(
+                ("attendee" if attendee_count == 1 else "attendees",
+                 attendee_count)
+            )
+        return blocking_children
 
     def get(self, request, *args, **kwargs):
         """Get the organisation_slug from the URL

--- a/django_project/certification/views/course.py
+++ b/django_project/certification/views/course.py
@@ -1,6 +1,4 @@
 # coding=utf-8
-from datetime import datetime, timedelta
-
 from base.models import Project
 from braces.views import LoginRequiredMixin
 from certification.mixins import (
@@ -520,11 +518,7 @@ class CourseDetailView(
                 course=self.course, attendee=course_attendee.attendee
             ).first()
             if certificate:
-                course_attendee.editable = (
-                    certificate.issue_date
-                    and certificate.issue_date + timedelta(days=7)
-                    > datetime.today().date()
-                )
+                course_attendee.editable = certificate.is_revocable
             else:
                 course_attendee.editable = True
         context["attendees"] = attendees

--- a/django_project/certification/views/course.py
+++ b/django_project/certification/views/course.py
@@ -12,6 +12,7 @@ from django.db import IntegrityError
 from django.db.models import QuerySet
 from django.http import Http404, HttpResponseRedirect
 from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import CreateView, DeleteView, DetailView, UpdateView
 
 from ..forms import CourseForm
@@ -308,6 +309,48 @@ class CourseDeleteView(
                  attendee_count)
             )
         return blocking_children
+
+    def get_permanent_certificate_count(self) -> int:
+        """Count certificates that are past their revocation window.
+
+        These can no longer be revoked, so unlike the other blockers there is
+        no sequence of steps that would let the course be deleted: it holds a
+        permanent record.
+
+        :returns: How many of this course's certificates are permanent.
+        :rtype: int
+        """
+
+        return sum(
+            1
+            for certificate in self.object.certificate_set.all()
+            if not certificate.is_revocable
+        )
+
+    def get_context_data(self, **kwargs):
+        """Tell the template which of the two situations applies."""
+
+        context = super(CourseDeleteView, self).get_context_data(**kwargs)
+        if getattr(self, "object", None) is not None:
+            context["permanent_certificate_count"] = (
+                self.get_permanent_certificate_count()
+            )
+        return context
+
+    def get_blocked_message(
+        self, blocking_children: list[tuple[str, int]]
+    ) -> str:
+        """Distinguish "not yet" from "not ever"."""
+
+        permanent_count = self.get_permanent_certificate_count()
+        if permanent_count:
+            return _(
+                "This course cannot be deleted. It holds %(count)s "
+                "certificate(s) that can no longer be revoked, so it is kept "
+                "as a permanent record."
+            ) % {"count": permanent_count}
+        return super(CourseDeleteView, self).get_blocked_message(
+            blocking_children)
 
     def get(self, request, *args, **kwargs):
         """Get the organisation_slug from the URL

--- a/django_project/certification/views/course.py
+++ b/django_project/certification/views/course.py
@@ -310,30 +310,13 @@ class CourseDeleteView(
             )
         return blocking_children
 
-    def get_permanent_certificate_count(self) -> int:
-        """Count certificates that are past their revocation window.
-
-        These can no longer be revoked, so unlike the other blockers there is
-        no sequence of steps that would let the course be deleted: it holds a
-        permanent record.
-
-        :returns: How many of this course's certificates are permanent.
-        :rtype: int
-        """
-
-        return sum(
-            1
-            for certificate in self.object.certificate_set.all()
-            if not certificate.is_revocable
-        )
-
     def get_context_data(self, **kwargs):
         """Tell the template which of the two situations applies."""
 
         context = super(CourseDeleteView, self).get_context_data(**kwargs)
         if getattr(self, "object", None) is not None:
             context["permanent_certificate_count"] = (
-                self.get_permanent_certificate_count()
+                self.object.permanent_certificate_count
             )
         return context
 
@@ -342,7 +325,7 @@ class CourseDeleteView(
     ) -> str:
         """Distinguish "not yet" from "not ever"."""
 
-        permanent_count = self.get_permanent_certificate_count()
+        permanent_count = self.object.permanent_certificate_count
         if permanent_count:
             return _(
                 "This course cannot be deleted. It holds %(count)s "

--- a/django_project/certification/views/course_type.py
+++ b/django_project/certification/views/course_type.py
@@ -11,6 +11,7 @@ from django.db import IntegrityError
 from django.db.models import QuerySet
 from django.http import Http404
 from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import CreateView, DeleteView, DetailView, UpdateView
 
 from ..forms import CourseTypeForm
@@ -117,6 +118,46 @@ class CourseTypeDeleteView(
             return []
         label = "course" if course_count == 1 else "courses"
         return [(label, course_count)]
+
+    def get_blocked_course_count(self) -> int:
+        """Count courses under this type that can never be deleted.
+
+        A course holding a certificate past its revocation window is
+        permanent, and so is this course type: no amount of tidying up the
+        other courses would free it. Surfacing that here saves the user
+        working through each course only to hit a dead end.
+
+        :returns: Number of courses holding a permanent certificate.
+        :rtype: int
+        """
+
+        courses = self.object.course_set.prefetch_related("certificate_set")
+        return sum(
+            1 for course in courses if course.permanent_certificate_count
+        )
+
+    def get_context_data(self, **kwargs):
+        """Tell the template which of the two situations applies."""
+
+        context = super(CourseTypeDeleteView, self).get_context_data(**kwargs)
+        if getattr(self, "object", None) is not None:
+            context["blocked_course_count"] = self.get_blocked_course_count()
+        return context
+
+    def get_blocked_message(
+        self, blocking_children: list[tuple[str, int]]
+    ) -> str:
+        """Distinguish "not yet" from "not ever"."""
+
+        blocked_courses = self.get_blocked_course_count()
+        if blocked_courses:
+            return _(
+                "This course type cannot be deleted. %(count)s of its courses "
+                "hold certificates that can no longer be revoked, so they are "
+                "kept as a permanent record."
+            ) % {"count": blocked_courses}
+        return super(CourseTypeDeleteView, self).get_blocked_message(
+            blocking_children)
 
     def get(self, request, *args, **kwargs):
         """

--- a/django_project/certification/views/course_type.py
+++ b/django_project/certification/views/course_type.py
@@ -1,9 +1,14 @@
 # coding=utf-8
 from base.models import Project
 from braces.views import LoginRequiredMixin
-from certification.mixins import ActiveCertifyingOrganisationRequiredMixin
+from certification.mixins import (
+    ActiveCertifyingOrganisationRequiredMixin,
+    OrganisationEditPermissionMixin,
+    ProtectChildrenDeleteMixin,
+)
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
+from django.db.models import QuerySet
 from django.http import Http404
 from django.urls import reverse
 from django.views.generic import CreateView, DeleteView, DetailView, UpdateView
@@ -22,6 +27,7 @@ class CourseTypeMixin(object):
 class CourseTypeCreateView(
     LoginRequiredMixin,
     ActiveCertifyingOrganisationRequiredMixin,
+    OrganisationEditPermissionMixin,
     CourseTypeMixin,
     CreateView,
 ):
@@ -86,13 +92,31 @@ class CourseTypeCreateView(
 
 
 class CourseTypeDeleteView(
-    LoginRequiredMixin, ActiveCertifyingOrganisationRequiredMixin, DeleteView
+    LoginRequiredMixin,
+    ActiveCertifyingOrganisationRequiredMixin,
+    OrganisationEditPermissionMixin,
+    ProtectChildrenDeleteMixin,
+    DeleteView,
 ):
     """Delete view for Course Type."""
 
     model = CourseType
     context_object_name = "coursetype"
     template_name = "course_type/delete.html"
+
+    def get_blocking_children(self) -> list[tuple[str, int]]:
+        """Courses cascade from a course type, taking their certificates and
+        attendees with them, so a course type with any course is protected.
+
+        :returns: (label, count) for the courses still using this type.
+        :rtype: list
+        """
+
+        course_count = self.object.course_set.count()
+        if not course_count:
+            return []
+        label = "course" if course_count == 1 else "courses"
+        return [(label, course_count)]
 
     def get(self, request, *args, **kwargs):
         """
@@ -173,6 +197,7 @@ class CourseTypeDeleteView(
 class CourseTypeUpdateView(
     LoginRequiredMixin,
     ActiveCertifyingOrganisationRequiredMixin,
+    OrganisationEditPermissionMixin,
     CourseTypeMixin,
     UpdateView,
 ):
@@ -220,14 +245,19 @@ class CourseTypeUpdateView(
         )
         return context
 
-    def get_queryset(self):
+    def get_queryset(self) -> QuerySet[CourseType]:
         """Get the queryset for this view.
 
-        :returns: query set that is all Course Type objects
+        Scoped to the organisation in the URL so a course type cannot be
+        edited through another organisation's address.
+
+        :returns: Course Type queryset filtered by Certifying Organisation
         :rtype: QuerySet
         """
 
-        qs = CourseType.objects.all()
+        qs = CourseType.objects.filter(
+            certifying_organisation=self.certifying_organisation
+        )
         return qs
 
     def get_success_url(self):


### PR DESCRIPTION
Closes #112

- **fix(certification): enforce course permissions server-side and block cascading deletes**
- **fix(certification): enforce revoke window on POST and restore credit refund**
- **feat(certification): distinguish permanently undeletable courses in the delete confirmation**
- **feat(certification): flag permanently undeletable course types up front**

When deleting a course with non-revokable certificates

<img width="1486" height="270" alt="image" src="https://github.com/user-attachments/assets/457be5d2-a24a-43fb-9138-4869fa87da26" />

When deleting a course with revokable certificates
<img width="1467" height="366" alt="image" src="https://github.com/user-attachments/assets/69030234-0c11-407b-a416-a33c2b462122" />


When deleting a course type

<img width="1450" height="246" alt="image" src="https://github.com/user-attachments/assets/713d5f73-8b2b-4007-89ef-8385679a3b68" />

AI Statement: This PR was assisted by AI
